### PR TITLE
Implement drag and drop interface for rearranging hint panels

### DIFF
--- a/app/models/hint_panel.rb
+++ b/app/models/hint_panel.rb
@@ -18,4 +18,8 @@ class HintPanel < ApplicationRecord
       typeData: panel_subtype.to_front_end,
     }
   end
+
+  def to_front_end_basic
+    { id:, name:, display_index: }
+  end
 end

--- a/bee-redux/package-lock.json
+++ b/bee-redux/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-template-redux",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/sortable": "^7.0.2",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.5",
@@ -2184,6 +2185,79 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
+      "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
+      "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.0.0",
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "peer": true
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-7.0.2.tgz",
+      "integrity": "sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.7",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.1.tgz",
+      "integrity": "sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.19",

--- a/bee-redux/package-lock.json
+++ b/bee-redux/package-lock.json
@@ -8,6 +8,8 @@
       "name": "vite-template-redux",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/modifiers": "^6.0.1",
         "@dnd-kit/sortable": "^7.0.2",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-collapsible": "^1.0.3",
@@ -2190,7 +2192,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
       "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -2201,14 +2202,12 @@
     "node_modules/@dnd-kit/accessibility/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "peer": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@dnd-kit/core": {
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.8.tgz",
       "integrity": "sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.0.0",
         "@dnd-kit/utilities": "^3.2.1",
@@ -2222,8 +2221,25 @@
     "node_modules/@dnd-kit/core/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "peer": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-6.0.1.tgz",
+      "integrity": "sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.1",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.0.6",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@dnd-kit/sortable": {
       "version": "7.0.2",

--- a/bee-redux/package.json
+++ b/bee-redux/package.json
@@ -14,6 +14,8 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "^7.0.2",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.0.3",

--- a/bee-redux/package.json
+++ b/bee-redux/package.json
@@ -14,6 +14,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "@dnd-kit/sortable": "^7.0.2",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.5",

--- a/bee-redux/src/components/IconButton.tsx
+++ b/bee-redux/src/components/IconButton.tsx
@@ -1,6 +1,8 @@
 import { Icon } from "@iconify/react";
 import { composeClasses } from "@/utils";
 import { BasicTooltip } from "@/components/BasicTooltip";
+import { DraggableAttributes } from "@dnd-kit/core";
+import { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 
 export interface IconButtonTypeData {
   name: string;
@@ -69,9 +71,11 @@ export const IconButtonTypes: IconButtonTypesData = {
 
 export interface IconButtonProps {
   type: IconButtonTypeKeys;
-  tooltip: string;
+  tooltip?: string;
   onClick?: Function;
   className?: string;
+  attributes?: DraggableAttributes;
+  listeners?: SyntheticListenerMap | undefined;
 }
 
 export function IconButton({
@@ -79,13 +83,17 @@ export function IconButton({
   onClick,
   tooltip,
   className,
+  attributes,
+  listeners,
 }: IconButtonProps) {
   return (
-    <BasicTooltip tooltipContent={tooltip}>
+    <BasicTooltip tooltipContent={tooltip} disabled={tooltip === undefined}>
       <button
         type="button"
         onClick={onClick ? () => onClick() : undefined}
         className={composeClasses("IconButton", className ?? "")}
+        {...attributes}
+        {...listeners}
       >
         <Icon icon={IconButtonTypes[type].icon} />
       </button>

--- a/bee-redux/src/features/hints/components/HintPanel.tsx
+++ b/bee-redux/src/features/hints/components/HintPanel.tsx
@@ -10,39 +10,87 @@ import {
   selectPanelDisplayState,
   setPanelDisplayPropThunk,
 } from "@/features/hints/hintProfilesSlice";
+import { CSSProperties, forwardRef, Ref } from "react";
+import { DraggableAttributes } from "@dnd-kit/core";
+import { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
+import { composeClasses } from "@/utils";
 
-export function HintPanel({ panel }: { panel: HintPanelData }) {
-  const dispatch = useAppDispatch();
-  const display = useAppSelector(selectPanelDisplayState(panel.id));
+export const HintPanel = forwardRef(
+  (
+    {
+      panel,
+      isOverlay,
+      isDragging,
+      isSorting,
+      style,
+      attributes,
+      listeners,
+    }: {
+      panel: HintPanelData;
+      isOverlay: boolean;
+      isDragging: boolean;
+      isSorting: boolean;
+      style?: CSSProperties;
+      attributes?: DraggableAttributes;
+      listeners?: SyntheticListenerMap | undefined;
+    },
+    ref: Ref<HTMLDivElement>,
+  ) => {
+    const dispatch = useAppDispatch();
+    const display = useAppSelector(selectPanelDisplayState(panel.id));
 
-  const toggleExpanded = () => {
-    dispatch(
-      setPanelDisplayPropThunk({
-        panelId: panel.id,
-        property: PanelCurrentDisplayStateProperties.isExpanded,
-        value: !display.isExpanded,
-      }),
+    const toggleExpanded = () => {
+      dispatch(
+        setPanelDisplayPropThunk({
+          panelId: panel.id,
+          property: PanelCurrentDisplayStateProperties.isExpanded,
+          value: !display.isExpanded,
+        }),
+      );
+    };
+
+    const cssClasses = () => {
+      let classes = "HintPanel";
+      if (isDragging && !isOverlay) {
+        classes = composeClasses(classes, "Dragging");
+      } else if (isOverlay) {
+        classes = composeClasses(classes, "Overlay");
+      }
+      if (isSorting) {
+        classes = composeClasses(classes, "Sorting");
+      }
+      return classes;
+    };
+
+    return (
+      <Collapsible.Root
+        ref={ref}
+        style={style}
+        className={cssClasses()}
+        open={display.isExpanded}
+      >
+        <PanelHeader
+          panelId={panel.id}
+          isPanelExpanded={display.isExpanded}
+          attributes={attributes}
+          listeners={listeners}
+        >
+          <Collapsible.Trigger asChild>
+            <button
+              className="HintPanelHeaderCollapseButton"
+              onClick={toggleExpanded}
+            >
+              <HeaderDisclosureWidget title={panel.name} />
+            </button>
+          </Collapsible.Trigger>
+        </PanelHeader>
+        <Collapsible.Content className="HintPanelContent">
+          {display.isSettingsExpanded ? (
+            <HintPanelSettings panel={panel} />
+          ) : null}
+          <HintPanelContentContainer panel={panel} />
+        </Collapsible.Content>
+      </Collapsible.Root>
     );
-  };
-
-  return (
-    <Collapsible.Root className="HintPanel" open={display.isExpanded}>
-      <PanelHeader panelId={panel.id} isPanelExpanded={display.isExpanded}>
-        <Collapsible.Trigger asChild>
-          <button
-            className="HintPanelHeaderCollapseButton"
-            onClick={toggleExpanded}
-          >
-            <HeaderDisclosureWidget title={panel.name} />
-          </button>
-        </Collapsible.Trigger>
-      </PanelHeader>
-      <Collapsible.Content className="HintPanelContent">
-        {display.isSettingsExpanded ? (
-          <HintPanelSettings panel={panel} />
-        ) : null}
-        <HintPanelContentContainer panel={panel} />
-      </Collapsible.Content>
-    </Collapsible.Root>
-  );
-}
+  },
+);

--- a/bee-redux/src/features/hints/components/HintPanel.tsx
+++ b/bee-redux/src/features/hints/components/HintPanel.tsx
@@ -29,7 +29,7 @@ export const HintPanel = forwardRef(
       panel: HintPanelData;
       isOverlay: boolean;
       isDragging: boolean;
-      isSorting: boolean;
+      isSorting?: boolean;
       style?: CSSProperties;
       attributes?: DraggableAttributes;
       listeners?: SyntheticListenerMap | undefined;

--- a/bee-redux/src/features/hints/components/HintPanels.tsx
+++ b/bee-redux/src/features/hints/components/HintPanels.tsx
@@ -1,14 +1,80 @@
 import { HintPanel } from "./HintPanel";
-import { hintApiSlice } from "@/features/hints/hintApiSlice";
+import { hintApiSlice, selectPanelIds, selectPanels } from "@/features/hints/hintApiSlice";
+import React, { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+  DragStartEvent,
+  DragOverlay,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { useAppSelector } from "@/app/hooks";
+import { SortableHintPanel } from "@/features/hints/components/SortableHintPanel";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { HintPanelData } from "@/features/hints";
 
 export function HintPanels() {
   const currentProfile =
     hintApiSlice.endpoints.getCurrentHintProfile.useQueryState(undefined);
+  const panels = useAppSelector(selectPanels);
+  const panelIds = useAppSelector(selectPanelIds);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const [activePanel, setActivePanel] = useState<HintPanelData | null>(null);
+  const handleDragStart = (e: DragStartEvent) => {
+    const { active } = e;
+    const maybeActivePanel = panels.find((panel) => panel.id === active.id);
+    if (maybeActivePanel) {
+      setActivePanel(maybeActivePanel);
+    }
+  };
+  const handleDragEnd = (e: DragEndEvent) => {
+    const { active, over } = e;
+    console.log("active:", active.id, "over:", over?.id);
+    if (active.id !== over?.id) {
+      console.log("move");
+    } else {
+      console.log("no move");
+    }
+    setActivePanel(null);
+  };
   return (
     <div className="HintPanels">
-      {currentProfile.data?.panels.map((panel, i) => {
-        return <HintPanel key={`hintPanel ${i}`} panel={panel} />;
-      })}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis]}
+      >
+        <SortableContext
+          items={panelIds}
+          strategy={verticalListSortingStrategy}
+        >
+          {currentProfile.data?.panels.map((panel) => {
+            return <SortableHintPanel key={panel.id} panel={panel} />;
+          })}
+        </SortableContext>
+        <DragOverlay>
+          {activePanel ? (
+            <HintPanel panel={activePanel} isOverlay={true} isDragging={true} />
+          ) : null}
+        </DragOverlay>
+      </DndContext>
     </div>
   );
 }

--- a/bee-redux/src/features/hints/components/HintPanels.tsx
+++ b/bee-redux/src/features/hints/components/HintPanels.tsx
@@ -1,5 +1,10 @@
 import { HintPanel } from "./HintPanel";
-import { hintApiSlice, selectPanelIds, selectPanels } from "@/features/hints/hintApiSlice";
+import {
+  hintApiSlice,
+  selectPanelIds,
+  selectPanels,
+  useChangeHintPanelOrderMutation,
+} from "@/features/hints/hintApiSlice";
 import React, { useState } from "react";
 import {
   DndContext,
@@ -13,7 +18,6 @@ import {
   DragOverlay,
 } from "@dnd-kit/core";
 import {
-  arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
@@ -35,6 +39,8 @@ export function HintPanels() {
     }),
   );
   const [activePanel, setActivePanel] = useState<HintPanelData | null>(null);
+  const [changeHintPanelOrder] = useChangeHintPanelOrderMutation();
+
   const handleDragStart = (e: DragStartEvent) => {
     const { active } = e;
     const maybeActivePanel = panels.find((panel) => panel.id === active.id);
@@ -42,16 +48,19 @@ export function HintPanels() {
       setActivePanel(maybeActivePanel);
     }
   };
+
   const handleDragEnd = (e: DragEndEvent) => {
     const { active, over } = e;
-    console.log("active:", active.id, "over:", over?.id);
-    if (active.id !== over?.id) {
-      console.log("move");
-    } else {
-      console.log("no move");
+    if (over && active.id !== over.id) {
+      changeHintPanelOrder({
+        id: Number(active.id),
+        oldIndex: panelIds.indexOf(Number(active.id)),
+        newIndex: panelIds.indexOf(Number(over.id)),
+      });
     }
     setActivePanel(null);
   };
+
   return (
     <div className="HintPanels">
       <DndContext

--- a/bee-redux/src/features/hints/components/PanelOverlay.tsx
+++ b/bee-redux/src/features/hints/components/PanelOverlay.tsx
@@ -1,0 +1,7 @@
+export function PanelOverlay() {
+  return (
+    <div className="PanelOverlay">
+      PanelOverlay
+    </div>
+  );
+}

--- a/bee-redux/src/features/hints/components/SortableHintPanel.tsx
+++ b/bee-redux/src/features/hints/components/SortableHintPanel.tsx
@@ -1,0 +1,33 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { HintPanelData } from "@/features/hints";
+import { HintPanel } from "@/features/hints/components/HintPanel";
+
+export function SortableHintPanel({ panel }: { panel: HintPanelData }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isSorting,
+  } = useSortable({ id: panel.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <HintPanel
+      ref={setNodeRef}
+      panel={panel}
+      isOverlay={false}
+      isDragging={isDragging}
+      isSorting={isSorting}
+      style={style}
+      attributes={attributes}
+      listeners={listeners}
+    />
+  );
+}

--- a/bee-redux/src/features/hints/components/shared/DragHandle.tsx
+++ b/bee-redux/src/features/hints/components/shared/DragHandle.tsx
@@ -1,11 +1,20 @@
 import { IconButton, IconButtonTypeKeys } from "@/components/IconButton";
+import { DraggableAttributes } from "@dnd-kit/core";
+import { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 
-export function DragHandle() {
+export function DragHandle({
+  attributes,
+  listeners,
+}: {
+  attributes?: DraggableAttributes;
+  listeners?: SyntheticListenerMap | undefined;
+}) {
   return (
     <IconButton
       type={IconButtonTypeKeys.DragVertical}
       className="DragHandle HintPanelHeaderButton button"
-      tooltip="Drag and drop to change panel order"
+      attributes={attributes}
+      listeners={listeners}
     />
   );
 }

--- a/bee-redux/src/features/hints/components/shared/PanelHeader.tsx
+++ b/bee-redux/src/features/hints/components/shared/PanelHeader.tsx
@@ -1,20 +1,25 @@
 import { RemoveButton } from "./RemoveButton";
 import { DuplicateButton } from "./DuplicateButton";
 import { ReactNode } from "react";
-import { IconButton, IconButtonTypeKeys } from "@/components/IconButton";
 import { DragHandle } from "@/features/hints/components/shared/DragHandle";
 import { SettingsToggle } from "@/features/hints/components/shared/SettingsToggle";
+import { DraggableAttributes } from "@dnd-kit/core";
+import { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 
 interface PanelHeaderProps {
   panelId: number;
   isPanelExpanded: boolean;
   children: ReactNode;
+  attributes?: DraggableAttributes;
+  listeners?: SyntheticListenerMap | undefined;
 }
 
 export function PanelHeader({
   panelId,
   isPanelExpanded,
   children,
+  attributes,
+  listeners,
 }: PanelHeaderProps) {
   const cssClasses = () => {
     let classList = "HintPanelHeader";
@@ -29,7 +34,7 @@ export function PanelHeader({
   return (
     <header className={cssClasses()}>
       <div className="PanelHeaderButtonGroup">
-        <DragHandle />
+        <DragHandle attributes={attributes} listeners={listeners} />
         <SettingsToggle panelId={panelId} />
       </div>
       {children}

--- a/bee-redux/src/features/hints/hintApiSlice.ts
+++ b/bee-redux/src/features/hints/hintApiSlice.ts
@@ -14,6 +14,7 @@ import {
   FetchBaseQueryMeta,
 } from "@reduxjs/toolkit/query";
 import { selectCurrentAttemptId } from "@/features/guesses/guessesSlice";
+import { createSelector } from "@reduxjs/toolkit";
 
 const maybeFindDefaultHintProfile = (
   formData: t.CurrentHintProfileFormData,
@@ -350,3 +351,13 @@ export const {
 
 export const selectCurrentHintProfile = (state: RootState) =>
   hintApiSlice.endpoints.getCurrentHintProfile.select()(state).data;
+
+export const selectPanels = createSelector(
+  [selectCurrentHintProfile],
+  (profile) => profile?.panels ?? [],
+);
+
+export const selectPanelIds = createSelector([selectPanels], (panels) => {
+  if (!panels) return [];
+  return panels.map((panel) => panel.id);
+});

--- a/bee-redux/src/features/hints/types/index.ts
+++ b/bee-redux/src/features/hints/types/index.ts
@@ -398,6 +398,12 @@ export interface RailsHintPanelUpdateForm {
   };
 }
 
+export type MoveHintPanelData = {
+  id: number;
+  oldIndex: number;
+  newIndex: number;
+};
+
 export enum HintProfileTypes {
   Default = "DefaultHintProfile",
   User = "UserHintProfile",

--- a/bee-redux/src/styles/hints.scss
+++ b/bee-redux/src/styles/hints.scss
@@ -63,6 +63,7 @@
 
 .HintPanel {
   $this-hue: $blue-hue;
+  position: relative;
   border-radius: var(--br);
   border: 2px solid border-color($this-hue);
   overflow: hidden;
@@ -70,6 +71,16 @@
   &[data-state="closed"] {
     color: $line-bright;
     border-color: border-color-disabled($this-hue);
+  }
+  &.Dragging {
+    opacity: 20%;
+  }
+  &.Overlay {
+    opacity: 80%;
+    outline: 3px dotted;
+  }
+  &.Sorting {
+    border-color: border-color-hover($this-hue);
   }
 }
 
@@ -105,9 +116,6 @@
   &.button {
     font-size: 20px;
     background-color: bg-color-extra($this-hue);
-    &:focus {
-      box-shadow: 0 0 0 2px bg-color-darkest($this-hue);
-    }
   }
   &:hover {
     border-color: border-color($this-hue);
@@ -125,21 +133,12 @@
 
 button.IconButton.DragHandle {
   $this-hue: $blue-hue;
-  //padding: 8px 3px;
-  //border-width: 2px;
-
-  //background-color: bg-color($this-hue);
   cursor: grab;
-  &:hover {
-    //border-style: dashed;
-    //border-color: border-color-hover($this-hue);
-  }
-  &:active {
+  .HintPanel.Overlay & {
     cursor: grabbing;
     background-color: $line-main;
     color: bg-color($this-hue);
   }
-  //border: 1.5px solid border-color($this-hue);
 }
 
 button.PanelSettingsToggle {
@@ -365,6 +364,12 @@ button.PanelSettingsToggle {
     align-items: center;
     justify-content: space-between;
   }
+}
+
+.PanelOverlay {
+  background-color: white;
+  color: black;
+  padding: 24px;
 }
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,9 @@ Rails.application.routes.draw do
       # Hints
       get "hint_profiles", to: "user_hint_profiles#get_all_hint_profiles"
       resources :user_hint_profiles
-      resources :hint_panels, except: [:index, :show]
+      resources :hint_panels, except: [:index, :show] do
+        put "move", on: :collection
+      end
       # Search panel searches
       get "search_panel_search/:attempt_id",
         to: "search_panel_searches#for_attempt_and_profile"

--- a/db/migrate/20230815073035_create_hint_panels.rb
+++ b/db/migrate/20230815073035_create_hint_panels.rb
@@ -8,7 +8,7 @@ class CreateHintPanels < ActiveRecord::Migration[7.0]
       t.references :status_tracking, type: :string, null: false, foreign_key: {to_table: :status_tracking_options, primary_key: :key}
       t.references :panel_subtype, polymorphic: true, null: false
       t.integer :display_index
-      t.check_constraint "display_index > 0", name: "positive_display_index"
+      t.check_constraint "display_index >= 0", name: "non_negative_display_index"
 
       t.timestamps
     end

--- a/db/migrate/20230828060858_add_display_index_to_hint_panels.rb
+++ b/db/migrate/20230828060858_add_display_index_to_hint_panels.rb
@@ -2,7 +2,7 @@ class AddDisplayIndexToHintPanels < ActiveRecord::Migration[7.0]
   def change
     unless column_exists?(:hint_panels, :display_index)
       add_column :hint_panels, :display_index, :integer
-      add_check_constraint :hint_panels, "display_index > 0", name: "positive_display_index"
+      add_check_constraint :hint_panels, "display_index >= 0", name: "non_negative_display_index"
     end
   end
 end

--- a/db/migrate/20230913100015_change_display_index_constraint.rb
+++ b/db/migrate/20230913100015_change_display_index_constraint.rb
@@ -1,0 +1,6 @@
+class ChangeDisplayIndexConstraint < ActiveRecord::Migration[7.0]
+  def change
+    remove_check_constraint :hint_panels, name: "positive_display_index"
+    add_check_constraint :hint_panels, "display_index >= 0", name: "non_negative_display_index"
+  end
+end

--- a/db/seeds/seed_hint_profiles.rb
+++ b/db/seeds/seed_hint_profiles.rb
@@ -25,7 +25,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Lengths - First Letter",
-      display_index: 1,
+      display_index: 0,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_length_grid",
@@ -38,7 +38,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Count - First 2 Letters",
-      display_index: 2,
+      display_index: 1,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_count_list",
@@ -51,7 +51,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Letter Search",
-      display_index: 3,
+      display_index: 2,
       panel_subtype: SearchPanel.new(
         location: "anywhere",
         output_type: "word_length_grid",
@@ -62,7 +62,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Obscurity Ranking",
-      display_index: 4,
+      display_index: 3,
       panel_subtype: ObscurityPanel.new(
         hide_known: false,
         separate_known: false,
@@ -76,7 +76,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Definitions",
-      display_index: 5,
+      display_index: 4,
       panel_subtype: DefinitionPanel.new(
         hide_known: false,
         revealed_letters: 1,
@@ -94,7 +94,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Your Grid of Remaining Words",
-      display_index: 1,
+      display_index: 0,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_length_grid",
@@ -110,7 +110,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Your Two-Letter List",
-      display_index: 2,
+      display_index: 1,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_count_list",
@@ -126,7 +126,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Obscurity Ranking",
-      display_index: 3,
+      display_index: 2,
       panel_subtype: ObscurityPanel.new(
         hide_known: true,
         separate_known: false,
@@ -143,7 +143,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Definitions",
-      display_index: 4,
+      display_index: 3,
       panel_subtype: DefinitionPanel.new(
         hide_known: true,
         revealed_letters: 1,
@@ -188,7 +188,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Search",
-      display_index: 1,
+      display_index: 0,
       panel_subtype: SearchPanel.new(
         location: "anywhere",
         output_type: "word_length_grid",
@@ -199,7 +199,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "First Letter WLG",
-      display_index: 2,
+      display_index: 1,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_length_grid",
@@ -212,7 +212,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "First 2 Letters WCL",
-      display_index: 3,
+      display_index: 2,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_count_list",
@@ -261,7 +261,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "First 2 Letters WLG",
-      display_index: 1,
+      display_index: 0,
       panel_subtype: LetterPanel.new(
         location: "start",
         output_type: "word_length_grid",
@@ -274,7 +274,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Search",
-      display_index: 2,
+      display_index: 1,
       panel_subtype: SearchPanel.new(
         location: "anywhere",
         output_type: "word_length_grid",
@@ -285,7 +285,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Obscurity Ranking",
-      display_index: 3,
+      display_index: 2,
       panel_subtype: ObscurityPanel.new(
         hide_known: false,
         revealed_letters: 1,
@@ -299,7 +299,7 @@ module SeedHintProfiles
 
     HintPanel.create!(
       name: "Word Definitions",
-      display_index: 4,
+      display_index: 3,
       panel_subtype: DefinitionPanel.new(
         hide_known: true,
         revealed_letters: 1,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -228,7 +228,7 @@ CREATE TABLE public.hint_panels (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     display_index integer,
-    CONSTRAINT positive_display_index CHECK ((display_index > 0))
+    CONSTRAINT non_negative_display_index CHECK ((display_index >= 0))
 );
 
 
@@ -1320,6 +1320,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230911051856'),
 ('20230912194527'),
 ('20230912210851'),
-('20230912212040');
+('20230912212040'),
+('20230913100015');
 
 


### PR DESCRIPTION
## Description
Use the [DND Kit](https://dndkit.com/) library to add the ability to rearrange the order of hint panels for a hint profile. This change enables the drag handle (the left-most button in the hint panel header) to enable dragging the hint panel to move it to a different index.

When the panel is dropped, the current hint profile's panel array is optimistically updated on the front end via RTK Query's `updateQueryData` utility function ([link](https://redux-toolkit.js.org/rtk-query/api/created-api/api-slice-utils#updatequerydata)), then the `display_index` of any affected panels is updated to reflect the panel's new position, then a PUT request is made to the server to update the hint panels on the back end at the `api/v1/hint_panels/move` endpoint.

Putting this into its own endpoint seemed appropriate since multiple panels need to be updated for the move action, whereas the normal CRUD panel update endpoint is designed for updating just the panel with the specified ID.

## Fixes
Closes #1 