### PR TITLE
Configure and re-export Radix UI primitives

### DIFF
--- a/bee-redux/src/components/HelpBubble.tsx
+++ b/bee-redux/src/components/HelpBubble.tsx
@@ -1,21 +1,13 @@
-import * as Popover from "@radix-ui/react-popover";
+import * as Popover from "@/components/radix-ui/radix-popover";
 import { ReactNode } from "react";
 
 export function HelpBubble({ children }: { children: ReactNode }) {
   return (
     <Popover.Root>
       <Popover.Trigger className="HelpBubbleTrigger">?</Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          className="HelpBubbleContent PopoverContent"
-          side="top"
-          avoidCollisions={true}
-          collisionPadding={16}
-        >
-          {children}
-          <Popover.Arrow className="PopoverArrow" width={12} height={8} />
-        </Popover.Content>
-      </Popover.Portal>
+      <Popover.ContentWithPortal className="HelpBubbleContent">
+        {children}
+      </Popover.ContentWithPortal>
     </Popover.Root>
   );
 }

--- a/bee-redux/src/components/SettingsCollapsible.tsx
+++ b/bee-redux/src/components/SettingsCollapsible.tsx
@@ -1,6 +1,5 @@
-import * as Collapsible from "@radix-ui/react-collapsible";
+import * as Collapsible from "@/components/radix-ui/radix-collapsible";
 import { SettingsHeader } from "./SettingsHeader";
-import { HeaderDisclosureWidget } from "@/components/HeaderDisclosureWidget";
 import React from "react";
 
 export function SettingsCollapsible({
@@ -15,14 +14,11 @@ export function SettingsCollapsible({
   return (
     <Collapsible.Root className="SettingsCollapsible" open={isExpanded}>
       <SettingsHeader>
-        <Collapsible.Trigger asChild>
-          <button
-            className="SettingsCollapsibleHeaderButton"
-            onClick={() => toggleIsExpanded()}
-          >
-            <HeaderDisclosureWidget title="Settings" />
-          </button>
-        </Collapsible.Trigger>
+        <Collapsible.Trigger
+          className="SettingsCollapsibleHeaderButton"
+          onClick={() => toggleIsExpanded()}
+          title="Settings"
+        />
       </SettingsHeader>
       <Collapsible.Content>{children}</Collapsible.Content>
     </Collapsible.Root>

--- a/bee-redux/src/components/radix-ui/radix-collapsible.tsx
+++ b/bee-redux/src/components/radix-ui/radix-collapsible.tsx
@@ -1,0 +1,19 @@
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { CollapsibleTriggerProps } from "@radix-ui/react-collapsible";
+import { RefAttributes } from "react";
+import { HeaderDisclosureWidget } from "@/components/HeaderDisclosureWidget";
+import IntrinsicAttributes = React.JSX.IntrinsicAttributes;
+
+export { Root, Content } from "@radix-ui/react-collapsible";
+
+export const Trigger = (
+  props: IntrinsicAttributes &
+    CollapsibleTriggerProps &
+    RefAttributes<HTMLButtonElement> & { title: string },
+) => (
+  <Collapsible.Trigger asChild>
+    <button {...props}>
+      <HeaderDisclosureWidget title={props.title} />
+    </button>
+  </Collapsible.Trigger>
+);

--- a/bee-redux/src/components/radix-ui/radix-dropdown-menu.tsx
+++ b/bee-redux/src/components/radix-ui/radix-dropdown-menu.tsx
@@ -1,0 +1,65 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import {
+  DropdownMenuContentProps,
+  DropdownMenuItemProps,
+  DropdownMenuSeparatorProps,
+} from "@radix-ui/react-dropdown-menu";
+import { RefAttributes } from "react";
+import { composeClasses } from "@/util";
+import IntrinsicAttributes = React.JSX.IntrinsicAttributes;
+
+export {
+  CheckboxItem,
+  Group,
+  ItemIndicator,
+  Label,
+  RadioGroup,
+  RadioItem,
+  Root,
+  Sub,
+  SubContent,
+  SubTrigger,
+  Trigger,
+} from "@radix-ui/react-dropdown-menu";
+
+export const ContentWithPortal = (
+  props: IntrinsicAttributes &
+    DropdownMenuContentProps &
+    RefAttributes<HTMLDivElement>,
+) => (
+  <DropdownMenu.Portal>
+    <DropdownMenu.Content
+      {...props}
+      className={composeClasses("UserMenuContent", props.className ?? "")}
+      avoidCollisions={props.avoidCollisions ?? true}
+      collisionPadding={props.collisionPadding ?? 24}
+    >
+      {props.children}
+      <DropdownMenu.Arrow className="Arrow" width={10} height={5} />
+    </DropdownMenu.Content>
+  </DropdownMenu.Portal>
+);
+
+export const Item = (
+  props: IntrinsicAttributes &
+    DropdownMenuItemProps &
+    RefAttributes<HTMLDivElement>,
+) => (
+  <DropdownMenu.Item
+    {...props}
+    className={composeClasses("MenuItem", props.className ?? "")}
+  >
+    {props.children}
+  </DropdownMenu.Item>
+);
+
+export const Separator = (
+  props: IntrinsicAttributes &
+    DropdownMenuSeparatorProps &
+    RefAttributes<HTMLDivElement>,
+) => (
+  <DropdownMenu.Separator
+    {...props}
+    className={composeClasses("Separator", props.className ?? "")}
+  />
+);

--- a/bee-redux/src/components/radix-ui/radix-popover.tsx
+++ b/bee-redux/src/components/radix-ui/radix-popover.tsx
@@ -1,6 +1,5 @@
 import * as Popover from "@radix-ui/react-popover";
 import {
-  PopoverArrowProps,
   PopoverCloseProps,
   PopoverContentProps,
 } from "@radix-ui/react-popover";
@@ -21,23 +20,13 @@ export const ContentWithPortal = (
       {...props}
       className={composeClasses("PopoverContent", props.className ?? "")}
       side={props.side ?? "top"}
-      avoidCollisions={true}
-      collisionPadding={16}
+      avoidCollisions={props.avoidCollisions ?? true}
+      collisionPadding={props.collisionPadding ?? 16}
     >
       {props.children}
+      <Popover.Arrow className="PopoverArrow" width={12} height={8} />
     </Popover.Content>
   </Popover.Portal>
-);
-
-export const Arrow = (
-  props: IntrinsicAttributes & PopoverArrowProps & RefAttributes<SVGSVGElement>,
-) => (
-  <Popover.Arrow
-    {...props}
-    className={composeClasses("PopoverArrow", props.className ?? "")}
-  >
-    {props.children}
-  </Popover.Arrow>
 );
 
 export const Close = (

--- a/bee-redux/src/components/radix-ui/radix-scroll-area.tsx
+++ b/bee-redux/src/components/radix-ui/radix-scroll-area.tsx
@@ -1,0 +1,20 @@
+import * as ScrollArea from "@radix-ui/react-scroll-area";
+import { ScrollAreaScrollbarProps } from "@radix-ui/react-scroll-area";
+import { RefAttributes } from "react";
+import { composeClasses } from "@/util";
+import IntrinsicAttributes = React.JSX.IntrinsicAttributes;
+
+export { Root, Viewport } from "@radix-ui/react-scroll-area";
+
+export const Scrollbar = (
+  props: IntrinsicAttributes &
+    ScrollAreaScrollbarProps &
+    RefAttributes<HTMLDivElement>,
+) => (
+  <ScrollArea.Scrollbar
+    {...props}
+    className={composeClasses("ScrollAreaScrollbar", props.className ?? "")}
+  >
+    <ScrollArea.Thumb className="ScrollAreaThumb" />
+  </ScrollArea.Scrollbar>
+);

--- a/bee-redux/src/components/radix-ui/radix-select.tsx
+++ b/bee-redux/src/components/radix-ui/radix-select.tsx
@@ -9,7 +9,8 @@ import { Icon } from "@iconify/react";
 import { composeClasses } from "@/util";
 import IntrinsicAttributes = React.JSX.IntrinsicAttributes;
 
-export const SelectTrigger = (
+export { Group, Root, Viewport } from "@radix-ui/react-select";
+export const Trigger = (
   props: IntrinsicAttributes &
     SelectTriggerProps &
     RefAttributes<HTMLButtonElement>,
@@ -27,7 +28,7 @@ export const SelectTrigger = (
   </Select.Trigger>
 );
 
-export const SelectContentWithPortal = (
+export const ContentWithPortal = (
   props: IntrinsicAttributes &
     SelectContentProps &
     RefAttributes<HTMLDivElement>,
@@ -54,7 +55,7 @@ interface SelectItemPropsExtended extends Select.SelectItemProps {
   itemText?: string;
 }
 
-export const SelectItem = ({
+export const Item = ({
   itemText,
   ...props
 }: IntrinsicAttributes &
@@ -74,7 +75,7 @@ export const SelectItem = ({
   </Select.Item>
 );
 
-export const SelectLabel = (
+export const Label = (
   props: IntrinsicAttributes & SelectLabelProps & RefAttributes<HTMLDivElement>,
 ) => (
   <Select.Label

--- a/bee-redux/src/components/radix-ui/radix-tabs.tsx
+++ b/bee-redux/src/components/radix-ui/radix-tabs.tsx
@@ -2,16 +2,13 @@ import * as Tabs from "@radix-ui/react-tabs";
 import {
   TabsContentProps,
   TabsListProps,
-  TabsProps,
   TabsTriggerProps,
 } from "@radix-ui/react-tabs";
 import { RefAttributes } from "react";
 import { composeClasses } from "@/util";
 import IntrinsicAttributes = React.JSX.IntrinsicAttributes;
 
-export const Root = (
-  props: IntrinsicAttributes & TabsProps & RefAttributes<HTMLDivElement>,
-) => <Tabs.Root {...props}>{props.children}</Tabs.Root>;
+export { Root } from "@radix-ui/react-tabs";
 
 export const List = (
   props: IntrinsicAttributes & TabsListProps & RefAttributes<HTMLDivElement>,

--- a/bee-redux/src/components/radix-ui/radix-toggle-group.tsx
+++ b/bee-redux/src/components/radix-ui/radix-toggle-group.tsx
@@ -1,12 +1,13 @@
 import * as ToggleGroup from "@radix-ui/react-toggle-group";
 import {
-  ToggleGroupItemProps,
   ToggleGroupMultipleProps,
   ToggleGroupSingleProps,
 } from "@radix-ui/react-toggle-group";
 import { RefAttributes } from "react";
 import { composeClasses } from "@/util";
 import IntrinsicAttributes = React.JSX.IntrinsicAttributes;
+
+export { Item } from "@radix-ui/react-toggle-group";
 
 export const Root = (
   props: IntrinsicAttributes &
@@ -20,9 +21,3 @@ export const Root = (
     {props.children}
   </ToggleGroup.Root>
 );
-
-export const Item = (
-  props: IntrinsicAttributes &
-    ToggleGroupItemProps &
-    RefAttributes<HTMLButtonElement>,
-) => <ToggleGroup.Item {...props}>{props.children}</ToggleGroup.Item>;

--- a/bee-redux/src/features/auth/headerAuth/UserMenu.tsx
+++ b/bee-redux/src/features/auth/headerAuth/UserMenu.tsx
@@ -1,11 +1,11 @@
 import { InlineIcon } from "@iconify/react";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import * as DropdownMenu from "@/components/radix-ui/radix-dropdown-menu";
 import { useLogoutMutation } from "../authApiSlice";
 import { useState } from "react";
 
 export function UserMenu() {
   const [logout] = useLogoutMutation();
-  const [buttonClasses, setButtonClasses] = useState("user-menu-trigger");
+  const [buttonClasses, setButtonClasses] = useState("UserMenuTrigger");
 
   const handleLogoutSelect = async () => {
     try {
@@ -39,41 +39,30 @@ export function UserMenu() {
             d="M12 19.2c-2.5 0-4.71-1.28-6-3.2c.03-2 4-3.1 6-3.1s5.97 1.1 6 3.1a7.232 7.232 0 0 1-6 3.2M12 5a3 3 0 0 1 3 3a3 3 0 0 1-3 3a3 3 0 0 1-3-3a3 3 0 0 1 3-3m0-3A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10c0-5.53-4.5-10-10-10Z"
           ></path>
         </svg>
-        {/*<Icon icon="mdi:account-circle" className="account-icon" />*/}
       </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          className="UserMenuContent"
-          avoidCollisions={true}
-          collisionPadding={24}
-        >
-          <DropdownMenu.Item className="MenuItem">
-            <InlineIcon icon="heroicons-outline:light-bulb" />
-            Hint Profiles
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className="MenuItem">
-            <InlineIcon icon="mdi:puzzle-outline" />
-            Puzzles
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className="MenuItem">
-            <InlineIcon icon="tabler:letter-w" />
-            Saved Words
-          </DropdownMenu.Item>
-          <DropdownMenu.Item className="MenuItem">
-            <InlineIcon icon="mdi:cog" />
-            Account
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator className="Separator" />
-          <DropdownMenu.Item
-            className="menu-item"
-            onSelect={handleLogoutSelect}
-          >
-            <InlineIcon icon="mdi:logout" />
-            Log Out
-          </DropdownMenu.Item>
-          <DropdownMenu.Arrow className="Arrow" width={10} height={5} />
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+      <DropdownMenu.ContentWithPortal>
+        <DropdownMenu.Item>
+          <InlineIcon icon="heroicons-outline:light-bulb" />
+          Hint Profiles
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <InlineIcon icon="mdi:puzzle-outline" />
+          Puzzles
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <InlineIcon icon="tabler:letter-w" />
+          Saved Words
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <InlineIcon icon="mdi:cog" />
+          Account
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item onSelect={handleLogoutSelect}>
+          <InlineIcon icon="mdi:logout" />
+          Log Out
+        </DropdownMenu.Item>
+      </DropdownMenu.ContentWithPortal>
     </DropdownMenu.Root>
   );
 }

--- a/bee-redux/src/features/guesses/components/attemptControls/AttemptSelector.tsx
+++ b/bee-redux/src/features/guesses/components/attemptControls/AttemptSelector.tsx
@@ -4,12 +4,7 @@ import {
   selectCurrentAttempt,
   setCurrentAttempt,
 } from "@/features/guesses";
-import * as Select from "@radix-ui/react-select";
-import {
-  SelectContentWithPortal,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/radix-ui/radix-select";
+import * as Select from "@/components/radix-ui/radix-select";
 import uniqid from "uniqid";
 
 export function AttemptSelector() {
@@ -21,12 +16,12 @@ export function AttemptSelector() {
       value={`${currentAttempt.id}`}
       onValueChange={(value) => dispatch(setCurrentAttempt(Number(value)))}
     >
-      <SelectTrigger />
-      <SelectContentWithPortal className="SelectContent">
+      <Select.Trigger />
+      <Select.ContentWithPortal className="SelectContent">
         <Select.Viewport>
           {attempts.map((attempt, i) => {
             return (
-              <SelectItem
+              <Select.Item
                 key={uniqid()}
                 value={`${attempt.id}`}
                 itemText={`Attempt ${i + 1}`}
@@ -34,7 +29,7 @@ export function AttemptSelector() {
             );
           })}
         </Select.Viewport>
-      </SelectContentWithPortal>
+      </Select.ContentWithPortal>
     </Select.Root>
   );
 }

--- a/bee-redux/src/features/hints/components/HintPanel.tsx
+++ b/bee-redux/src/features/hints/components/HintPanel.tsx
@@ -1,6 +1,5 @@
 import { PanelHeader } from "./shared/PanelHeader";
-import * as Collapsible from "@radix-ui/react-collapsible";
-import { HeaderDisclosureWidget } from "@/components/HeaderDisclosureWidget";
+import * as Collapsible from "@/components/radix-ui/radix-collapsible";
 import { HintPanelSettings } from "@/features/hints/components/settings/HintPanelSettings";
 import { HintPanelContentContainer } from "@/features/hints/components/shared/HintPanelContentContainer";
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
@@ -75,14 +74,11 @@ export const HintPanel = forwardRef(
           attributes={attributes}
           listeners={listeners}
         >
-          <Collapsible.Trigger asChild>
-            <button
-              className="HintPanelHeaderCollapseButton"
-              onClick={toggleExpanded}
-            >
-              <HeaderDisclosureWidget title={panel.name} />
-            </button>
-          </Collapsible.Trigger>
+          <Collapsible.Trigger
+            className="HintPanelHeaderCollapseButton"
+            onClick={toggleExpanded}
+            title={panel.name}
+          />
         </PanelHeader>
         <Collapsible.Content className="HintPanelContent">
           {display.isSettingsExpanded ? (

--- a/bee-redux/src/features/hints/components/profiles/HintProfilesSelector.tsx
+++ b/bee-redux/src/features/hints/components/profiles/HintProfilesSelector.tsx
@@ -1,10 +1,4 @@
-import * as Select from "@radix-ui/react-select";
-import {
-  SelectContentWithPortal,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-} from "@/components/radix-ui/radix-select";
+import * as Select from "@/components/radix-ui/radix-select";
 import uniqid from "uniqid";
 import {
   hintApiSlice,
@@ -49,21 +43,21 @@ export function HintProfilesSelector() {
       value={composeValueString(currentProfile.data)}
       onValueChange={(value) => handleSelect(value)}
     >
-      <SelectTrigger />
-      <SelectContentWithPortal>
+      <Select.Trigger />
+      <Select.ContentWithPortal>
         <Select.Viewport>
           <Select.Group>
-            <SelectLabel>My hint profiles</SelectLabel>
+            <Select.Label>My hint profiles</Select.Label>
             {profiles.data?.userHintProfiles.length ? (
               profiles.data.userHintProfiles.map((profile) => (
-                <SelectItem
+                <Select.Item
                   key={uniqid()}
                   value={composeValueString(profile)}
                   itemText={profile.name}
                 />
               ))
             ) : (
-              <SelectItem
+              <Select.Item
                 value=""
                 className="SelectItem"
                 itemText="No profiles"
@@ -72,9 +66,9 @@ export function HintProfilesSelector() {
             )}
           </Select.Group>
           <Select.Group>
-            <SelectLabel>Default hint profiles</SelectLabel>
+            <Select.Label>Default hint profiles</Select.Label>
             {profiles.data?.defaultHintProfiles.map((profile) => (
-              <SelectItem
+              <Select.Item
                 key={uniqid()}
                 value={composeValueString(profile)}
                 itemText={profile.name}
@@ -82,7 +76,7 @@ export function HintProfilesSelector() {
             ))}
           </Select.Group>
         </Select.Viewport>
-      </SelectContentWithPortal>
+      </Select.ContentWithPortal>
     </Select.Root>
   );
 }

--- a/bee-redux/src/features/hints/components/settings/HintLocationControl.tsx
+++ b/bee-redux/src/features/hints/components/settings/HintLocationControl.tsx
@@ -6,12 +6,7 @@ import {
   SearchPanelLocationOptions,
   useUpdateHintPanelMutation,
 } from "@/features/hints";
-import * as Select from "@radix-ui/react-select";
-import {
-  SelectContentWithPortal,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/radix-ui/radix-select";
+import * as Select from "@/components/radix-ui/radix-select";
 import uniqid from "uniqid";
 import { CSSProperties } from "react";
 
@@ -44,15 +39,15 @@ export function HintLocationControl({
     <div className="LetterPanelLocationControl" style={style}>
       <span>Location:</span>
       <Select.Root value={location} onValueChange={handleChange}>
-        <SelectTrigger className="SmallSelect" style={{ width: "12em" }} />
-        <SelectContentWithPortal className="SmallSelect">
+        <Select.Trigger className="SmallSelect" style={{ width: "12em" }} />
+        <Select.ContentWithPortal className="SmallSelect">
           <Select.Viewport>
             {Object.keys(
               panelType === PanelTypes.Letter
                 ? LetterPanelLocationOptions
                 : SearchPanelLocationOptions,
             ).map((key) => (
-              <SelectItem
+              <Select.Item
                 key={uniqid()}
                 value={key}
                 itemText={
@@ -63,7 +58,7 @@ export function HintLocationControl({
               />
             ))}
           </Select.Viewport>
-        </SelectContentWithPortal>
+        </Select.ContentWithPortal>
       </Select.Root>
     </div>
   );

--- a/bee-redux/src/features/hints/components/settings/HintOutputTypeControl.tsx
+++ b/bee-redux/src/features/hints/components/settings/HintOutputTypeControl.tsx
@@ -3,12 +3,7 @@ import {
   SubstringHintOutputOptions,
   useUpdateHintPanelMutation,
 } from "@/features/hints";
-import * as Select from "@radix-ui/react-select";
-import {
-  SelectContentWithPortal,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/radix-ui/radix-select";
+import * as Select from "@/components/radix-ui/radix-select";
 import uniqid from "uniqid";
 
 export function HintOutputTypeControl({
@@ -32,18 +27,18 @@ export function HintOutputTypeControl({
     <div className="HintOutputTypeControl">
       <span>Output:</span>
       <Select.Root value={outputType} onValueChange={handleChange}>
-        <SelectTrigger className="SmallSelect" style={{ width: "12em" }} />
-        <SelectContentWithPortal className="SmallSelect">
+        <Select.Trigger className="SmallSelect" style={{ width: "12em" }} />
+        <Select.ContentWithPortal className="SmallSelect">
           <Select.Viewport>
             {Object.keys(SubstringHintOutputOptions).map((key) => (
-              <SelectItem
+              <Select.Item
                 key={uniqid()}
                 value={key}
                 itemText={SubstringHintOutputOptions[key].title}
               />
             ))}
           </Select.Viewport>
-        </SelectContentWithPortal>
+        </Select.ContentWithPortal>
       </Select.Root>
     </div>
   );

--- a/bee-redux/src/features/hints/components/settings/PanelStatusTrackingControl.tsx
+++ b/bee-redux/src/features/hints/components/settings/PanelStatusTrackingControl.tsx
@@ -3,12 +3,7 @@ import {
   StatusTrackingOptions,
   useUpdateHintPanelMutation,
 } from "@/features/hints";
-import * as Select from "@radix-ui/react-select";
-import {
-  SelectContentWithPortal,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/radix-ui/radix-select";
+import * as Select from "@/components/radix-ui/radix-select";
 import uniqid from "uniqid";
 
 export function PanelStatusTrackingControl({
@@ -31,12 +26,12 @@ export function PanelStatusTrackingControl({
     <div className="GeneralPanelSettingsStatusTracking">
       <span>Display:</span>
       <Select.Root value={statusTracking} onValueChange={handleChange}>
-        <SelectTrigger className="SmallSelect" />
-        <SelectContentWithPortal className="SmallSelect">
+        <Select.Trigger className="SmallSelect" />
+        <Select.ContentWithPortal className="SmallSelect">
           <Select.Viewport>
             {Object.keys(StatusTrackingOptions).map((key) => {
               return (
-                <SelectItem
+                <Select.Item
                   key={uniqid()}
                   value={key}
                   itemText={StatusTrackingOptions[key].compactTitle}
@@ -44,7 +39,7 @@ export function PanelStatusTrackingControl({
               );
             })}
           </Select.Viewport>
-        </SelectContentWithPortal>
+        </Select.ContentWithPortal>
       </Select.Root>
     </div>
   );

--- a/bee-redux/src/features/wordLists/components/WordListScroller.tsx
+++ b/bee-redux/src/features/wordLists/components/WordListScroller.tsx
@@ -1,4 +1,4 @@
-import * as ScrollArea from "@radix-ui/react-scroll-area";
+import * as ScrollArea from "@/components/radix-ui/radix-scroll-area";
 import uniqid from "uniqid";
 import { WordWithPopover } from "./WordWithPopover";
 import { AnswerSpoiler } from "./answers/AnswerSpoiler";
@@ -35,12 +35,7 @@ export function WordListScroller({
           ))}
         </ul>
       </ScrollArea.Viewport>
-      <ScrollArea.Scrollbar
-        orientation="horizontal"
-        className="ScrollAreaScrollbar"
-      >
-        <ScrollArea.Thumb className="ScrollAreaThumb" />
-      </ScrollArea.Scrollbar>
+      <ScrollArea.Scrollbar orientation="horizontal" />
     </ScrollArea.Root>
   );
 }

--- a/bee-redux/src/features/wordLists/components/WordLists.tsx
+++ b/bee-redux/src/features/wordLists/components/WordLists.tsx
@@ -1,4 +1,4 @@
-import * as Tabs from "@radix-ui/react-tabs";
+import * as Tabs from "@/components/radix-ui/radix-tabs";
 import { FoundWordsContainer } from "./foundWords/FoundWordsContainer";
 import { WrongGuessesContainer } from "./wrongGuesses/WrongGuessesContainer";
 import { ExcludedWordsContainer } from "./excludedWords/ExcludedWordsContainer";
@@ -7,34 +7,23 @@ import { AnswersContainer } from "./answers/AnswersContainer";
 export function WordLists() {
   return (
     <div className="sb-word-list-section-container">
-      <Tabs.Root className="sb-word-tabs-root" defaultValue="foundWords">
-        <Tabs.List
-          className="TabsList"
-          style={{ gridTemplateColumns: "repeat(4, 1fr" }}
-        >
-          <Tabs.Trigger className="TabsTrigger" value="foundWords">
-            Found
-          </Tabs.Trigger>
-          <Tabs.Trigger className="TabsTrigger" value="wrongGuesses">
-            Wrong
-          </Tabs.Trigger>
-          <Tabs.Trigger className="TabsTrigger" value="excludedWords">
-            Excluded
-          </Tabs.Trigger>
-          <Tabs.Trigger className="TabsTrigger" value="answers">
-            Answers
-          </Tabs.Trigger>
+      <Tabs.Root defaultValue="foundWords">
+        <Tabs.List style={{ gridTemplateColumns: "repeat(4, 1fr" }}>
+          <Tabs.Trigger value="foundWords">Found</Tabs.Trigger>
+          <Tabs.Trigger value="wrongGuesses">Wrong</Tabs.Trigger>
+          <Tabs.Trigger value="excludedWords">Excluded</Tabs.Trigger>
+          <Tabs.Trigger value="answers">Answers</Tabs.Trigger>
         </Tabs.List>
-        <Tabs.Content className="TabsContent" value="foundWords">
+        <Tabs.Content value="foundWords">
           <FoundWordsContainer />
         </Tabs.Content>
-        <Tabs.Content className="TabsContent" value="wrongGuesses">
+        <Tabs.Content value="wrongGuesses">
           <WrongGuessesContainer />
         </Tabs.Content>
-        <Tabs.Content className="TabsContent" value="excludedWords">
+        <Tabs.Content value="excludedWords">
           <ExcludedWordsContainer />
         </Tabs.Content>
-        <Tabs.Content className="TabsContent" value="answers">
+        <Tabs.Content value="answers">
           <AnswersContainer />
         </Tabs.Content>
       </Tabs.Root>

--- a/bee-redux/src/features/wordLists/components/WordWithPopover.tsx
+++ b/bee-redux/src/features/wordLists/components/WordWithPopover.tsx
@@ -23,7 +23,6 @@ export function WordWithPopover({ word }: { word: string }) {
       <Popover.ContentWithPortal>
         <span>{completeWord?.definitions[0]}</span>
         <Popover.Close />
-        <Popover.Arrow width={12} height={8} />
       </Popover.ContentWithPortal>
     </Popover.Root>
   );

--- a/bee-redux/src/features/wordLists/components/answers/AnswersContainer.tsx
+++ b/bee-redux/src/features/wordLists/components/answers/AnswersContainer.tsx
@@ -10,7 +10,7 @@ import { SettingsCollapsible } from "@/components/SettingsCollapsible";
 import {
   selectAnswersListSettings,
   toggleAnswersSettingsCollapsed,
-} from "../../api/wordListSettingsSlice";
+} from "@/features/wordLists";
 import answerSorter from "./answerSorter";
 import { selectSpoiledWords } from "@/features/guesses";
 import { AnswersSettings } from "./AnswersSettings";

--- a/bee-redux/src/features/wordLists/components/answers/AnswersSettings.tsx
+++ b/bee-redux/src/features/wordLists/components/answers/AnswersSettings.tsx
@@ -6,8 +6,8 @@ import {
   setAnswersRemainingLocation,
   setAnswersRemainingRevealFirstLetter,
   setAnswersRemainingRevealLength,
-} from "../../api/wordListSettingsSlice";
-import * as ToggleGroup from "@radix-ui/react-toggle-group";
+} from "@/features/wordLists";
+import * as ToggleGroup from "@/components/radix-ui/radix-toggle-group";
 
 export function AnswersSettings() {
   const dispatch = useAppDispatch();
@@ -66,7 +66,6 @@ export function AnswersSettings() {
       <div>
         <ToggleGroup.Root
           type="single"
-          className="ToggleGroup"
           value={remainingLocation}
           onValueChange={(val) => dispatch(setAnswersRemainingLocation(val))}
         >

--- a/bee-redux/src/styles/_main.scss
+++ b/bee-redux/src/styles/_main.scss
@@ -457,9 +457,9 @@ a {
 
 .TabsList {
   display: grid;
-  //grid-template-columns: repeat(4, 1fr);
   gap: 2px;
 }
+
 .TabsTrigger {
   border-top: 2px solid;
   border-left: 2px solid;


### PR DESCRIPTION
## Description
This commit sets up the `components/radix-ui` directory with a file for each Radix UI component used. Each file imports, configures, and re-exports parts of a single Radix UI component for use in the app so that individual components only need to configure the bare minimum. Unmodified parts are simply re-exported.

## Related Issues
Resolves #33
