### PR TITLE
Standardize CSS class names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,22 +2,22 @@
 name: Bug report
 about: Create a bug report
 title: "[BUG]"
-labels: bug, cleanup
+labels: bug
 assignees: apmwebdev
 
 ---
 
-**Description**
+## Description
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## To Reproduce
 Steps to reproduce the behavior:
 1. 
 2. 
 3. 
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+## Screenshots
 If applicable, add screenshots to help explain your problem.

--- a/bee-redux/src/features/auth/Login.tsx
+++ b/bee-redux/src/features/auth/Login.tsx
@@ -47,27 +47,23 @@ export function Login() {
   };
 
   return (
-    <div className="sb-login">
-      <form
-        id="sb-page-login-form"
-        className="sb-login-form"
-        onSubmit={handleSubmit}
-      >
-        <div className="login-username-container">
-          <label htmlFor="login-username">Username:</label>
+    <div className="Login">
+      <form id="LoginForm" onSubmit={handleSubmit}>
+        <div className="LoginUsernameContainer">
+          <label htmlFor="LoginUsername">Username:</label>
           <input
             type="text"
-            id="login-username"
+            id="LoginUsername"
             name="login-username"
             value={usernameValue}
             onChange={(e) => setUsernameValue(e.target.value)}
           />
         </div>
-        <div className="login-username-container">
-          <label htmlFor="login-username">Password:</label>
+        <div className="LoginPasswordContainer">
+          <label htmlFor="LoginPassword">Password:</label>
           <input
             type="password"
-            id="login-password"
+            id="LoginPassword"
             name="login-password"
             value={passwordValue}
             onChange={(e) => setPasswordValue(e.target.value)}

--- a/bee-redux/src/features/auth/Signup.tsx
+++ b/bee-redux/src/features/auth/Signup.tsx
@@ -62,53 +62,53 @@ export function Signup() {
   };
 
   return (
-    <div className="sb-signup">
-      <form className="sb-signup-form" onSubmit={handleSubmit}>
-        <div className="signup-email-container">
-          <label htmlFor="signup-email">Email:</label>
+    <div className="Signup">
+      <form className="SignupForm" onSubmit={handleSubmit}>
+        <div className="SignupEmailContainer">
+          <label htmlFor="SignupEmail">Email:</label>
           <input
             type="email"
-            id="signup-email"
+            id="SignupEmail"
             name="signup-email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
           />
         </div>
-        <div className="signup-username-container">
-          <label htmlFor="signup-username">Username:</label>
+        <div className="SignupUsernameContainer">
+          <label htmlFor="SignupUsername">Username:</label>
           <input
             type="text"
-            id="signup-username"
+            id="SignupUsername"
             name="signup-username"
             value={usernameValue}
             onChange={(e) => setUsernameValue(e.target.value)}
           />
         </div>
-        <div className="signup-name-container">
-          <label htmlFor="signup-name">Name:</label>
+        <div className="SignupNameContainer">
+          <label htmlFor="SignupName">Name:</label>
           <input
             type="text"
-            id="signup-name"
+            id="SignupName"
             name="signup-name"
             value={nameValue}
             onChange={(e) => setNameValue(e.target.value)}
           />
         </div>
-        <div className="signup-password-container">
-          <label htmlFor="signup-password">Password:</label>
+        <div className="SignupPasswordContainer">
+          <label htmlFor="SignupPassword">Password:</label>
           <input
             type="password"
-            id="signup-password"
+            id="SignupPassword"
             name="signup-password"
             value={passwordValue}
             onChange={(e) => setPasswordValue(e.target.value)}
           />
         </div>
-        <div className="signup-password-confirm-container">
-          <label htmlFor="signup-password-confirm">Confirm password:</label>
+        <div className="SignupPasswordConfirmContainer">
+          <label htmlFor="SignupPasswordConfirm">Confirm password:</label>
           <input
             type="password"
-            id="signup-password-confirm"
+            id="SignupPasswordConfirm"
             name="signup-password-confirm"
             value={passwordConfirmValue}
             onChange={(e) => setPasswordConfirmValue(e.target.value)}

--- a/bee-redux/src/features/auth/headerAuth/UserMenu.tsx
+++ b/bee-redux/src/features/auth/headerAuth/UserMenu.tsx
@@ -19,7 +19,9 @@ export function UserMenu() {
     <DropdownMenu.Root>
       <DropdownMenu.Trigger
         className={buttonClasses}
-        onMouseEnter={() => setButtonClasses("UserMenuTrigger umt-hover")}
+        onMouseEnter={() =>
+          setButtonClasses("UserMenuTrigger UserMenuTrigger___hover")
+        }
         onMouseLeave={() => setButtonClasses("UserMenuTrigger")}
       >
         <svg
@@ -32,10 +34,20 @@ export function UserMenu() {
           height="1em"
           viewBox="0 0 24 24"
         >
-          <circle className="svg-border" r="11" cx="12" cy="12"></circle>
-          <circle className="svg-bg" r="7" cx="12" cy="12"></circle>
+          <circle
+            className="UserMenuTrigger_svgBorder"
+            r="11"
+            cx="12"
+            cy="12"
+          ></circle>
+          <circle
+            className="UserMenuTrigger_svgBackground"
+            r="7"
+            cx="12"
+            cy="12"
+          ></circle>
           <path
-            className="svg-fg"
+            className="UserMenuTrigger_svgForeground"
             d="M12 19.2c-2.5 0-4.71-1.28-6-3.2c.03-2 4-3.1 6-3.1s5.97 1.1 6 3.1a7.232 7.232 0 0 1-6 3.2M12 5a3 3 0 0 1 3 3a3 3 0 0 1-3 3a3 3 0 0 1-3-3a3 3 0 0 1 3-3m0-3A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10c0-5.53-4.5-10-10-10Z"
           ></path>
         </svg>

--- a/bee-redux/src/features/guesses/components/guessInput/GuessInputControls.tsx
+++ b/bee-redux/src/features/guesses/components/guessInput/GuessInputControls.tsx
@@ -3,7 +3,7 @@ import { GuessInputEnter } from "./controls/GuessInputEnter";
 
 export function GuessInputControls() {
   return (
-    <div className="sb-guess-input-controls">
+    <div className="GuessInputControls">
       <GuessInputBackspace />
       <div>blah</div>
       <GuessInputEnter />

--- a/bee-redux/src/features/guesses/components/guessInput/GuessInputDisplay.tsx
+++ b/bee-redux/src/features/guesses/components/guessInput/GuessInputDisplay.tsx
@@ -13,9 +13,9 @@ export function GuessInputDisplay({
   const centerLetter = useAppSelector(selectCenterLetter);
 
   const letterClasses = (letter: string) => {
-    let classList = "sb-guess-input-letter";
+    let classList = "GuessInputLetter";
     if (centerLetter === letter) {
-      return (classList += " center-letter");
+      return (classList += " centerLetter");
     }
     if (validLetters.includes(letter)) {
       return (classList += " valid");
@@ -27,9 +27,9 @@ export function GuessInputDisplay({
     guessValue: string,
     additionalCssClasses: string,
   ) => {
-    let classList = `sb-guess-input ${additionalCssClasses}`;
+    let classList = `GuessInput ${additionalCssClasses}`;
     if (guessValue.length > 0) {
-      classList += " non-empty";
+      classList += " nonEmpty";
     }
     return classList;
   };
@@ -45,7 +45,7 @@ export function GuessInputDisplay({
 
   return (
     <div
-      id="sb-guess-input"
+      id="GuessInput"
       className={containerClasses(guessValue, additionalCssClasses)}
     >
       {content(guessValue)}

--- a/bee-redux/src/features/guesses/components/guessInput/controls/GuessInputBackspace.tsx
+++ b/bee-redux/src/features/guesses/components/guessInput/controls/GuessInputBackspace.tsx
@@ -7,7 +7,7 @@ export function GuessInputBackspace() {
   return (
     <button
       type="button"
-      className="sb-guess-input-backspace standard-button"
+      className="GuessInputBackspace standardButton"
       onClick={guessBackspace}
     >
       Delete

--- a/bee-redux/src/features/guesses/components/guessInput/controls/GuessInputEnter.tsx
+++ b/bee-redux/src/features/guesses/components/guessInput/controls/GuessInputEnter.tsx
@@ -11,7 +11,7 @@ export function GuessInputEnter() {
   return (
     <button
       type="button"
-      className="sb-guess-input-enter standard-button"
+      className="GuessInputEnter standardButton"
       onClick={handleClick}
     >
       Enter

--- a/bee-redux/src/features/hints/components/HintPanel.tsx
+++ b/bee-redux/src/features/hints/components/HintPanel.tsx
@@ -75,7 +75,7 @@ export const HintPanel = forwardRef(
           listeners={listeners}
         >
           <Collapsible.Trigger
-            className="HintPanelHeaderCollapseButton"
+            className="HintPanelHeaderCollapseButton HintPanelHeaderButton"
             onClick={toggleExpanded}
             title={panel.name}
           />

--- a/bee-redux/src/features/hints/components/SearchHintPanel.tsx
+++ b/bee-redux/src/features/hints/components/SearchHintPanel.tsx
@@ -54,7 +54,7 @@ export function SearchHintPanel({
           placeholder="Search..."
           onChange={(e) => setSearchValue(e.target.value)}
         />
-        <button type="submit" className="standard-button">
+        <button type="submit" className="standardButton">
           Search
         </button>
       </form>

--- a/bee-redux/src/features/hints/components/shared/DragHandle.tsx
+++ b/bee-redux/src/features/hints/components/shared/DragHandle.tsx
@@ -12,7 +12,7 @@ export function DragHandle({
   return (
     <IconButton
       type={IconButtonTypeKeys.DragVertical}
-      className="DragHandle HintPanelHeaderButton button"
+      className="DragHandle HintPanelHeaderButton"
       attributes={attributes}
       listeners={listeners}
     />

--- a/bee-redux/src/features/hints/components/shared/DuplicateButton.tsx
+++ b/bee-redux/src/features/hints/components/shared/DuplicateButton.tsx
@@ -8,7 +8,7 @@ export function DuplicateButton({ panelId }: DuplicateButtonProps) {
   return (
     <IconButton
       type={IconButtonTypeKeys.Duplicate}
-      className="HintPanelHeaderButton button"
+      className="HintPanelHeaderButton"
       // onClick={() => dispatch(duplicatePanel({ panelId }))}
       tooltip="Duplicate panel"
     />

--- a/bee-redux/src/features/hints/components/shared/RemoveButton.tsx
+++ b/bee-redux/src/features/hints/components/shared/RemoveButton.tsx
@@ -8,7 +8,7 @@ export function RemoveButton({ panelId }: RemoveButtonProps) {
   return (
     <IconButton
       type={IconButtonTypeKeys.Close}
-      className="HintPanelHeaderButton button"
+      className="HintPanelHeaderButton"
       tooltip="Delete panel"
     />
   );

--- a/bee-redux/src/features/hints/components/shared/SettingsToggle.tsx
+++ b/bee-redux/src/features/hints/components/shared/SettingsToggle.tsx
@@ -21,7 +21,7 @@ export function SettingsToggle({ panelId }: { panelId: number }) {
   };
   return (
     <Toggle.Root
-      className="PanelSettingsToggle button"
+      className="PanelSettingsToggle HintPanelHeaderButton IconButton"
       pressed={display.isSettingsExpanded}
       onPressedChange={toggleExpanded}
       disabled={!display.isExpanded}

--- a/bee-redux/src/features/puzzle/components/Hive.tsx
+++ b/bee-redux/src/features/puzzle/components/Hive.tsx
@@ -1,14 +1,14 @@
-import React, { FC } from "react";
+import React from "react";
 import LetterCell from "./LetterCell";
 import { useAppSelector } from "@/app/hooks";
 import { selectPuzzle } from "@/features/puzzle";
 import uniqid from "uniqid";
 
-const Hive: FC = () => {
+export function Hive() {
   const puzzle = useAppSelector(selectPuzzle);
   return (
-    <div className="hive-container">
-      <div className="hive">
+    <div className="HiveContainer">
+      <div className="Hive">
         <LetterCell letter={puzzle.centerLetter} isCenter={true} />
         {puzzle.outerLetters.map((letter) => {
           return <LetterCell key={uniqid()} letter={letter} isCenter={false} />;
@@ -16,6 +16,4 @@ const Hive: FC = () => {
       </div>
     </div>
   );
-};
-
-export default Hive;
+}

--- a/bee-redux/src/features/puzzle/components/LetterCell.tsx
+++ b/bee-redux/src/features/puzzle/components/LetterCell.tsx
@@ -10,7 +10,7 @@ export default function LetterCell({ letter, isCenter }: LetterCellProps) {
   // TODO: Make these fully accessible buttons
   return (
     <svg
-      className={isCenter ? "hexagon center-letter" : "hexagon"}
+      className={isCenter ? "LetterCell centerLetter" : "LetterCell"}
       viewBox="0 0 140 121.2435565"
       onClick={handleClick}
       // tabIndex={0}

--- a/bee-redux/src/features/puzzle/components/Puzzle.tsx
+++ b/bee-redux/src/features/puzzle/components/Puzzle.tsx
@@ -1,4 +1,4 @@
-import Hive from "./Hive";
+import { Hive } from "./Hive";
 import { GuessInputProvider } from "@/app/GuessInputProvider";
 import { GuessInput, GuessInputControls } from "@/features/guesses";
 import { PuzzleNav } from "@/features/puzzle/components/PuzzleNav";

--- a/bee-redux/src/features/puzzleSearch/components/PuzzleSearch.tsx
+++ b/bee-redux/src/features/puzzleSearch/components/PuzzleSearch.tsx
@@ -19,7 +19,7 @@ export function PuzzleSearch() {
 
   return (
     <div className="PuzzleSearch">
-      <form className="sb-puzzle-search" onSubmit={handleSearch}>
+      <form className="PuzzleSearch" onSubmit={handleSearch}>
         <Icon icon="mdi:search" />
         <input
           type="text"

--- a/bee-redux/src/features/wordLists/components/WordListScroller.tsx
+++ b/bee-redux/src/features/wordLists/components/WordListScroller.tsx
@@ -29,7 +29,7 @@ export function WordListScroller({
   return (
     <ScrollArea.Root type="auto">
       <ScrollArea.Viewport>
-        <ul className="sb-word-list has-content">
+        <ul className="WordList hasContent">
           {wordList.map((word) => (
             <li key={uniqid()}>{listItem(word)}</li>
           ))}

--- a/bee-redux/src/features/wordLists/components/WordLists.tsx
+++ b/bee-redux/src/features/wordLists/components/WordLists.tsx
@@ -6,7 +6,7 @@ import { AnswersContainer } from "./answers/AnswersContainer";
 
 export function WordLists() {
   return (
-    <div className="sb-word-list-section-container">
+    <div className="WordLists">
       <Tabs.Root defaultValue="foundWords">
         <Tabs.List style={{ gridTemplateColumns: "repeat(4, 1fr" }}>
           <Tabs.Trigger value="foundWords">Found</Tabs.Trigger>

--- a/bee-redux/src/features/wordLists/components/answers/AnswerSpoiler.tsx
+++ b/bee-redux/src/features/wordLists/components/answers/AnswerSpoiler.tsx
@@ -39,7 +39,7 @@ export function AnswerSpoiler({ word }: { word: string }) {
 
     return (
       <button
-        className="sb-revealer"
+        className="Revealer"
         style={{ width: `${determineWidth()}px` }}
         onClick={() => addGuess(spoilerData)}
       >

--- a/bee-redux/src/features/wordLists/components/answers/AnswersContainer.tsx
+++ b/bee-redux/src/features/wordLists/components/answers/AnswersContainer.tsx
@@ -47,19 +47,19 @@ export function AnswersContainer() {
   });
 
   return (
-    <div className="sb-answers-container">
+    <div className="AnswersContainer">
       <SettingsCollapsible
         isExpanded={!settingsCollapsed}
         toggleIsExpanded={() => dispatch(toggleAnswersSettingsCollapsed())}
       >
         <AnswersSettings />
       </SettingsCollapsible>
-      <div className="sb-answers-status sb-word-list-status">
+      <div className="AnswersStatus WordListStatus">
         There are{" "}
-        <span className="word-list-status-count">{answerWords.length}</span>{" "}
+        <span className="WordListStatusCount">{answerWords.length}</span>{" "}
         answers for this puzzle.
       </div>
-      <div className="sb-word-list-container">
+      <div className="WordListContainer">
         <AnswersListHeader />
         <WordListScroller
           wordList={displayList}

--- a/bee-redux/src/features/wordLists/components/answers/AnswersSettings.tsx
+++ b/bee-redux/src/features/wordLists/components/answers/AnswersSettings.tsx
@@ -19,7 +19,7 @@ export function AnswersSettings() {
     remainingGroupWithLetter,
   } = useAppSelector(selectAnswersListSettings);
   return (
-    <div className="sb-word-list-settings-content answers">
+    <div className="WordListSettingsContent answers">
       <label>
         <input
           type="checkbox"

--- a/bee-redux/src/features/wordLists/components/excludedWords/ExcludedWordsContainer.tsx
+++ b/bee-redux/src/features/wordLists/components/excludedWords/ExcludedWordsContainer.tsx
@@ -6,7 +6,7 @@ import {
   selectExcludedWordsListSettings,
   SortOrder,
   toggleExcludedWordsSettingsCollapsed,
-} from "../../api/wordListSettingsSlice";
+} from "@/features/wordLists";
 import { SettingsCollapsible } from "@/components/SettingsCollapsible";
 
 export function ExcludedWordsContainer() {
@@ -18,7 +18,7 @@ export function ExcludedWordsContainer() {
   const displayList = [...excludedWords];
 
   return (
-    <div className="sb-excluded-words-container">
+    <div className="ExcludedWordsContainer">
       <SettingsCollapsible
         isExpanded={!settingsCollapsed}
         toggleIsExpanded={() =>
@@ -27,12 +27,12 @@ export function ExcludedWordsContainer() {
       >
         blah
       </SettingsCollapsible>
-      <div className="sb-excluded-words-status sb-word-list-status">
+      <div className="WordListStatus">
         There are{" "}
-        <span className="word-list-status-count">{excludedWords.length}</span>{" "}
+        <span className="WordListStatusCount">{excludedWords.length}</span>{" "}
         words excluded from this puzzle.
       </div>
-      <div className="sb-word-list-container">
+      <div className="WordListContainer">
         <ExcludedWordsListHeader />
         <WordListScroller
           wordList={

--- a/bee-redux/src/features/wordLists/components/excludedWords/ExcludedWordsListHeader.tsx
+++ b/bee-redux/src/features/wordLists/components/excludedWords/ExcludedWordsListHeader.tsx
@@ -2,7 +2,7 @@ import {
   selectExcludedWordsListSettings,
   setExcludedWordsSortOrder,
   SortOrder,
-} from "../../api/wordListSettingsSlice";
+} from "@/features/wordLists";
 import * as ToggleGroup from "@/components/radix-ui/radix-toggle-group";
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
 
@@ -11,12 +11,11 @@ export function ExcludedWordsListHeader() {
   const { sortOrder } = useAppSelector(selectExcludedWordsListSettings);
 
   return (
-    <header className="header">
-      <div className="sort-order">
+    <header>
+      <div>
         <span>Order</span>
         <ToggleGroup.Root
           type="single"
-          className="sb-wrong-guesses-sort-order"
           value={sortOrder}
           onValueChange={(val) => dispatch(setExcludedWordsSortOrder(val))}
         >

--- a/bee-redux/src/features/wordLists/components/foundWords/FoundWordsContainer.tsx
+++ b/bee-redux/src/features/wordLists/components/foundWords/FoundWordsContainer.tsx
@@ -5,7 +5,7 @@ import {
   SortOrder,
   SortType,
   toggleFoundWordsSettingsCollapsed,
-} from "../../api/wordListSettingsSlice";
+} from "@/features/wordLists";
 import { WordListScroller } from "../WordListScroller";
 import { FoundWordsStatus } from "./FoundWordsStatus";
 import { FoundWordsListHeader } from "./FoundWordsListHeader";
@@ -54,16 +54,16 @@ export function FoundWordsContainer() {
     const wordsOnly = displayGuessList.map((guess) => guess.text);
     if (wordsOnly.length > 0) {
       return (
-        <div className="sb-word-list-container">
+        <div className="WordListContainer">
           <FoundWordsListHeader />
           <WordListScroller wordList={wordsOnly} allowPopovers={true} />
         </div>
       );
     }
-    return <div className="sb-word-list empty">No found words</div>;
+    return <div className="WordList empty">No found words</div>;
   };
   return (
-    <div className="sb-found-words-container">
+    <div className="FoundWordsContainer">
       <SettingsCollapsible
         isExpanded={!settingsCollapsed}
         toggleIsExpanded={() => dispatch(toggleFoundWordsSettingsCollapsed())}

--- a/bee-redux/src/features/wordLists/components/foundWords/FoundWordsListHeader.tsx
+++ b/bee-redux/src/features/wordLists/components/foundWords/FoundWordsListHeader.tsx
@@ -4,7 +4,7 @@ import {
   setFoundWordsSortType,
   SortOrder,
   SortType,
-} from "../../api/wordListSettingsSlice";
+} from "@/features/wordLists";
 import * as ToggleGroup from "@/components/radix-ui/radix-toggle-group";
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
 
@@ -13,12 +13,11 @@ export function FoundWordsListHeader() {
   const { sortType, sortOrder } = useAppSelector(selectFoundWordsListSettings);
 
   return (
-    <header className="header">
-      <div className="sort-type">
+    <header>
+      <div>
         <span>Sort</span>
         <ToggleGroup.Root
           type="single"
-          className="sb-found-words-sort-order"
           value={sortType}
           onValueChange={(val) => dispatch(setFoundWordsSortType(val))}
         >
@@ -30,11 +29,10 @@ export function FoundWordsListHeader() {
           </ToggleGroup.Item>
         </ToggleGroup.Root>
       </div>
-      <div className="sort-order">
+      <div>
         <span>Order</span>
         <ToggleGroup.Root
           type="single"
-          className="sb-found-words-sort-type"
           value={sortOrder}
           onValueChange={(val) => dispatch(setFoundWordsSortOrder(val))}
         >

--- a/bee-redux/src/features/wordLists/components/foundWords/FoundWordsSettings.tsx
+++ b/bee-redux/src/features/wordLists/components/foundWords/FoundWordsSettings.tsx
@@ -4,7 +4,7 @@ import {
   setFoundWordsPerfectPangramsShowTotal,
   setFoundWordsShowPerfectPangrams,
   setFoundWordsWordsShowTotal,
-} from "../../api/wordListSettingsSlice";
+} from "@/features/wordLists";
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
 
 export function FoundWordsSettings() {
@@ -16,7 +16,7 @@ export function FoundWordsSettings() {
     perfectPangramsShowTotal,
   } = useAppSelector(selectFoundWordsListSettings);
   return (
-    <div className="sb-word-list-settings-content found">
+    <div className="WordListSettingsContent found">
       <label>
         <input
           type="checkbox"
@@ -39,7 +39,6 @@ export function FoundWordsSettings() {
       </label>
       <label>
         <input
-          id="sb-found-words-list-show-perfect"
           type="checkbox"
           checked={showPerfectPangrams}
           onChange={(e) =>
@@ -50,7 +49,6 @@ export function FoundWordsSettings() {
       </label>
       <label>
         <input
-          id="sb-found-words-list-perfect-include-total"
           type="checkbox"
           checked={perfectPangramsShowTotal}
           disabled={!showPerfectPangrams}

--- a/bee-redux/src/features/wordLists/components/foundWords/FoundWordsStatus.tsx
+++ b/bee-redux/src/features/wordLists/components/foundWords/FoundWordsStatus.tsx
@@ -6,7 +6,7 @@ import {
   selectPerfectPangrams,
   selectTotalPoints,
 } from "@/features/puzzle";
-import { selectFoundWordsListSettings } from "../../api/wordListSettingsSlice";
+import { selectFoundWordsListSettings } from "@/features/wordLists";
 
 export function FoundWordsStatus() {
   const {

--- a/bee-redux/src/features/wordLists/components/wrongGuesses/WrongGuessesContainer.tsx
+++ b/bee-redux/src/features/wordLists/components/wrongGuesses/WrongGuessesContainer.tsx
@@ -45,16 +45,16 @@ export function WrongGuessesContainer() {
   };
 
   return (
-    <div className="sb-wrong-guesses-container">
+    <div>
       <SettingsCollapsible
         isExpanded={!settingsCollapsed}
         toggleIsExpanded={() => dispatch(toggleWrongGuessesSettingsCollapsed())}
       >
         No content
       </SettingsCollapsible>
-      <div className="sb-wrong-guesses-status sb-word-list-status">
+      <div className="WordListStatus">
         You've made{" "}
-        <span className="word-list-status-count">{wrongGuesses.length}</span>{" "}
+        <span className="WordListStatusCount">{wrongGuesses.length}</span>{" "}
         incorrect {wrongGuesses.length === 1 ? "guess" : "guesses"}.
       </div>
       <WrongGuessesListContainer wordList={generateDisplayGuessList()} />

--- a/bee-redux/src/features/wordLists/components/wrongGuesses/WrongGuessesListContainer.tsx
+++ b/bee-redux/src/features/wordLists/components/wrongGuesses/WrongGuessesListContainer.tsx
@@ -8,10 +8,10 @@ export function WrongGuessesListContainer({
 }) {
   const content = () => {
     if (wordList.length === 0) {
-      return <div className="sb-word-list empty">No incorrect guesses</div>;
+      return <div className="WordList empty">No incorrect guesses</div>;
     }
     return (
-      <div className="sb-word-list-container">
+      <div className="WordListContainer">
         <WrongGuessesListHeader />
         <WordListScroller wordList={wordList} allowPopovers={false} />
       </div>

--- a/bee-redux/src/features/wordLists/components/wrongGuesses/WrongGuessesListHeader.tsx
+++ b/bee-redux/src/features/wordLists/components/wrongGuesses/WrongGuessesListHeader.tsx
@@ -20,7 +20,6 @@ export function WrongGuessesListHeader() {
         <span>Sort</span>
         <ToggleGroup.Root
           type="single"
-          className="sb-wrong-guesses-sort-type"
           value={sortType}
           onValueChange={(val) => dispatch(setWrongGuessesSortType(val))}
         >
@@ -36,7 +35,6 @@ export function WrongGuessesListHeader() {
         <span>Order</span>
         <ToggleGroup.Root
           type="single"
-          className="sb-wrong-guesses-sort-order"
           value={sortOrder}
           onValueChange={(val) => dispatch(setWrongGuessesSortOrder(val))}
         >

--- a/bee-redux/src/styles/_animation.scss
+++ b/bee-redux/src/styles/_animation.scss
@@ -18,7 +18,7 @@
   transform: rotate(0deg);
 }
 
-.sb-answer-alert-message, .sb-answer-alert-score {
+.AnswerAlertMessage, .AnswerAlertScore {
   animation-duration: 0.7s;
   animation-timing-function:
           cubic-bezier(0.33, 1, 0.68, 1),
@@ -27,7 +27,7 @@
   animation-iteration-count: 1;
 }
 
-.sb-answer-alert-message {
+.AnswerAlertMessage {
   animation-name: float-up-slow, fade-out;
 
   @keyframes float-up-slow {
@@ -39,7 +39,7 @@
     }
   }
 }
-.sb-answer-alert-score {
+.AnswerAlertScore {
   animation-name: float-up-fast, fade-out;
 
   @keyframes float-up-fast {
@@ -61,7 +61,7 @@
   }
 }
 
-.sb-guess-input {
+.GuessInput {
   &.error {
     animation-name: shake;
     animation-duration: 0.4s;

--- a/bee-redux/src/styles/_main.scss
+++ b/bee-redux/src/styles/_main.scss
@@ -72,7 +72,7 @@
 
 button {
   border-radius: var(--br);
-  cursor: pointer;
+  //cursor: pointer;
 }
 
 .IconButton {
@@ -108,7 +108,7 @@ button {
   }
 }
 
-.standard-button {
+.standardButton {
   @include basic-focus;
   font-size: 16px;
   padding: 8px 16px;
@@ -181,9 +181,6 @@ a.ButtonLink, div.ButtonLink {
 }
 
 /***   Input   ***/
-
-input, input[type="number"] {
-}
 
 input[type="text"], input[type="search"] {
   padding: 4px 8px;
@@ -481,7 +478,15 @@ a {
   padding: 8px;
 }
 
-/*** Toggle Group   ***/
+/***   Toggle   ***/
+
+.ToggleRoot {
+  &[data-disabled] {
+    cursor: not-allowed;
+  }
+}
+
+/***   Toggle Group   ***/
 
 .ToggleGroup {
   $this-hue: $accent-hue;

--- a/bee-redux/src/styles/_utility-classes.scss
+++ b/bee-redux/src/styles/_utility-classes.scss
@@ -13,7 +13,7 @@
   cursor: not-allowed;
 }
 
-.display-none {
+.displayNone {
   display: none;
 }
 

--- a/bee-redux/src/styles/header.scss
+++ b/bee-redux/src/styles/header.scss
@@ -54,15 +54,15 @@
   font-size: 30px;
   //background-color: $line-bright;
 }
-.svg-fg {
+.UserMenuTrigger_svgForeground {
   fill: ui-bg-color($accent-hue);
 }
-.svg-bg {
+.UserMenuTrigger_svgBackground {
   fill: $line-main;
 }
-.svg-border {
+.UserMenuTrigger_svgBorder {
   fill: transparent;
-  .umt-hover & {
+  .UserMenuTrigger___hover & {
     fill: ui-line-hover-color($accent-hue);
   }
 }

--- a/bee-redux/src/styles/hints.scss
+++ b/bee-redux/src/styles/hints.scss
@@ -67,7 +67,6 @@
   border-radius: var(--br);
   border: 2px solid border-color($this-hue);
   overflow: hidden;
-  //border-color: border-color($this-hue);
   &[data-state="closed"] {
     color: $line-bright;
     border-color: border-color-disabled($this-hue);
@@ -92,7 +91,6 @@
   gap: 6px;
   padding: 3px 4px;
   background-color: bg-color($this-hue);
-  //border-bottom: 1.5px solid bg-color($this-hue);
   .HintPanel[data-state="closed"] & {
     background-color: bg-color-disabled($this-hue);
 
@@ -104,7 +102,7 @@
   gap: 6px;
 }
 
-.HintPanelHeader button {
+button.HintPanelHeaderButton {
   $this-hue: $blue_hue;
   font-size: 18px;
   display: flex;
@@ -113,16 +111,19 @@
   font-weight: bold;
   padding: 8px;
   border: 1.5px solid transparent;
-  &.button {
+  &.IconButton {
     font-size: 20px;
     background-color: bg-color-extra($this-hue);
   }
   &:hover {
     border-color: border-color($this-hue);
   }
+  &:focus {
+    box-shadow: 0 0 0 1px shadow-color-focus($this-hue)
+  }
   .HintPanel[data-state="closed"] & {
     color: $line-bright;
-    &.button {
+    &.IconButton {
       background-color: bg-color-disabled($this-hue);
     }
     &:hover {
@@ -133,9 +134,8 @@
 
 button.IconButton.DragHandle {
   $this-hue: $blue-hue;
-  cursor: grab;
+  cursor: move;
   .HintPanel.Overlay & {
-    cursor: grabbing;
     background-color: $line-main;
     color: bg-color($this-hue);
   }
@@ -144,9 +144,6 @@ button.IconButton.DragHandle {
 button.PanelSettingsToggle {
   $this-hue: $blue-hue;
   padding: 8px;
-  //flex-direction: column;
-  //background-color: bg-color-darker($this-hue);
-  //border: 1.5px solid border-color($this-hue);
   color: $line-main;
   &[data-state="on"] {
     background-color: $line-main;
@@ -234,13 +231,6 @@ button.PanelSettingsToggle {
   left: -18px;
 }
 
-.sb-hint-panel-header-buttons-left, .sb-hint-panel-header-buttons-right {
-  grid-row: 1 / 2;
-  display: flex;
-  gap: 8px;
-  /*margin-bottom: 8px;*/
-}
-
 .GeneralPanelSettings {
   border-top: 2px solid border-color($alt-bg-hue);
   display: grid;
@@ -271,7 +261,6 @@ button.PanelSettingsToggle {
 .PanelInitialDisplayControls {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  //grid-template-rows: 1fr 1fr;
   align-items: flex-start;
   justify-content: stretch;
   gap: 12px;
@@ -381,9 +370,6 @@ button.PanelSettingsToggle {
 
 
 
-
-.LetterPanelSettings {
-}
 
 .LetterPanelNumberOfLettersInput {
   width: 3rem;
@@ -518,9 +504,6 @@ button.PanelSettingsToggle {
 
 
 
-
-.SearchPanelSettings {
-}
 
 .SearchHintPanel {
   //padding: 8px;

--- a/bee-redux/src/styles/puzzle.scss
+++ b/bee-redux/src/styles/puzzle.scss
@@ -76,7 +76,7 @@
   margin-top: 8px;
 }
 
-.sb-guess-input {
+.GuessInput {
   position: relative;
   display: flex;
   align-items: center;
@@ -99,14 +99,14 @@
   }
 }
 
-.sb-guess-input-letter {
+.GuessInputLetter {
   font-size: 36px;
   text-transform: uppercase;
   font-weight: bold;
   &.valid {
     color: white;
   }
-  &.center-letter {
+  &.centerLetter {
     color: $yellow-line;
   }
   &.invalid {
@@ -114,17 +114,17 @@
   }
 }
 
-.hive-container {
+.HiveContainer {
   width: 90%;
 }
 
-.hive {
+.Hive {
   position: relative;
   width: 100%;
   padding-bottom: 103.6085%;
 }
 
-.hexagon {
+.LetterCell {
   position: absolute;
   top: 33.333333333%;
   left: 30%;
@@ -137,7 +137,7 @@
   text {
     fill: $line-main;
   }
-  &.center-letter polygon {
+  &.centerLetter polygon {
     fill: $yellow-main; //#887711
   }
   &:focus {
@@ -148,40 +148,40 @@
   /*margin: 4px;*/
 }
 
-.hexagon text {
+.LetterCell text {
   text-anchor: middle;
   font-size: 36px;
   font-weight: bold;
 }
 
-.hexagon:nth-child(1) {
+.LetterCell:nth-child(1) {
 }
 
-.hexagon:nth-child(2) {
+.LetterCell:nth-child(2) {
   transform: translate(-75%, -50%);
 }
 
-.hexagon:nth-child(3) {
+.LetterCell:nth-child(3) {
   transform: translate(0%, -100%);
 }
 
-.hexagon:nth-child(4) {
+.LetterCell:nth-child(4) {
   transform: translate(75%, -50%);
 }
 
-.hexagon:nth-child(5) {
+.LetterCell:nth-child(5) {
   transform: translate(75%, 50%);
 }
 
-.hexagon:nth-child(6) {
+.LetterCell:nth-child(6) {
   transform: translate(0%, 100%);
 }
 
-.hexagon:nth-child(7) {
+.LetterCell:nth-child(7) {
   transform: translate(-75%, 50%);
 }
 
-.sb-guess-input-controls {
+.GuessInputControls {
   display: grid;
   //width: 100%;
   grid-template-columns: 1fr max-content 1fr;
@@ -189,7 +189,7 @@
   justify-content: center;
   gap: 16px;
   padding: 16px;
-  .standard-button {
+  .standardButton {
     background-color: $mid-gray-darker;
   }
 }

--- a/bee-redux/src/styles/status.scss
+++ b/bee-redux/src/styles/status.scss
@@ -1,16 +1,13 @@
 @use 'colors' as *;
 
 .Status {
-  /*border: 1px solid #ccc;*/
   position: sticky;
   top: 8px;
   display: flex;
   flex-direction: column;
-  //padding: 8px;
   gap: 8px;
   justify-content: flex-start;
   align-self: flex-start;
-  //height: 100vh;
   width: 100%;
   max-width: 33.333333333vw;
 }
@@ -20,26 +17,15 @@
   font-size: 16px;
   display: flex;
   align-items: center;
-  //justify-content: center;
   justify-content: flex-start;
   gap: 16px;
   background-color: bg-color-dark($this-hue);
-  //border: 1.5px solid border-color($this-hue);
   padding: 8px 16px;
-  //margin: 8px 0px;
   border-radius: var(--br);
 }
 
 .Progress {
-  //border-radius: 24px;
-  //border: 2px solid border-color($blue-hue);
   padding: 0px 16px;
-  .sb-found-words-status {
-    padding-bottom: 4px;
-  }
-  //border-top: 2px solid $mid-gray;
-  //margin: 8px;
-  //background-color: bg-color-darker($blue-hue);
 }
 
 .ProgressRank {
@@ -72,9 +58,6 @@
   width: 14px;
   border-radius: 14px;
   background-color: $mid-gray;
-  &.active {
-    //background-color: ui-bg-color($yellow-hue);
-  }
   &:not(:first-child):before {
     content: "";
     position: absolute;
@@ -119,17 +102,7 @@
   }
 }
 
-.sb-word-list-section-container {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  //border: 2px solid;
-  //border-radius: var(--br);
-  margin: 0px;
-  //padding: 8px;
-}
-
-.sb-word-list-settings-content {
+.WordListSettingsContent {
   padding: 8px;
   label, > div {
     display: flex;
@@ -147,19 +120,13 @@
     flex-direction: column;
     gap: 4px;
   }
-  .sb-word-list-toggle {
-    font-size: 16px;
-    button {
-      padding: 2px 8px;
-    }
-  }
 }
 
-.sb-word-list-status {
+.WordListStatus {
   padding: 16px 8px;
   align-items: center;
   font-size: 16px;
-  &.sb-found-words-status {
+  &.FoundWordsStatus {
     display: flex;
     justify-content: center;
     gap: 20px;
@@ -168,12 +135,12 @@
       gap: 4px;
     }
   }
-  .word-list-status-count {
+  .WordListStatusCount {
     font-weight: bold;
   }
 }
 
-.sb-word-list-container {
+.WordListContainer {
   border-radius: var(--br);
   border: 1px solid $line-darkest;
   overflow: hidden;
@@ -192,10 +159,10 @@
   }
 }
 
-.sb-word-list {
+.WordList {
   padding: 8px 8px 16px 8px;
   //border: 1px dotted;
-  &.has-content {
+  &.hasContent {
     font-size: 16px;
     list-style: none;
     text-align: left;
@@ -212,7 +179,7 @@
           text-transform: uppercase;
         }
       }
-      button.word-popover-trigger {
+      button.WordPopoverTrigger {
         padding: 0px;
         border: none;
         display: flex;
@@ -241,13 +208,13 @@
   }
 }
 
-.has-popover {
+.hasPopover {
   &.perfect, &.pangram {
     color: $yellow-line;
   }
 }
 
-button.sb-revealer {
+button.Revealer {
   padding: 3px 8px;
   border: 1px solid $mid-gray;
   //border-radius: 0px;


### PR DESCRIPTION
## Description
This commit changes CSS classes to use Pascal case for component and element classes and camel case for modifier classes. This will make the style more consistent and make it easier to migrate to a CSS in JS solution in the future, if that becomes necessary.

## Related Issues
Resolves #32
