### PR TITLE
Add excluded_words cache to db for performance

### DIFF
--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -14,22 +14,34 @@ class Puzzle < ApplicationRecord
   has_many :words, through: :answers
   has_many :user_puzzle_attempts
 
-  attr_accessor :pangrams, :perfect_pangrams, :valid_letters, :excluded_words,
-    :is_latest
+  attr_accessor :pangrams, :perfect_pangrams, :valid_letters, :is_latest
 
   def set_valid_letters
     @valid_letters ||= [center_letter, *outer_letters].sort
+  end
+
+  def create_excluded_words_cache
+    return unless excluded_words.nil?
+    set_valid_letters
+    valid_letters_regex = "^[#{valid_letters.join("")}]+$"
+    excluded_words_array = Word
+      .where("CHAR_LENGTH(text) >= 4")
+      .where("text ~ ?", valid_letters_regex)
+      .where("text LIKE ?", "%#{center_letter}%")
+      .where.not(text: words.select(:text))
+      .pluck(:text)
+    update!(excluded_words: excluded_words_array)
   end
 
   def set_pangrams
     @pangrams ||= []
     return unless @pangrams.empty?
     set_valid_letters
-    potential_pangrams = Answer.where(puzzle_id: id).where("length(word_text) >= 7")
-    potential_pangrams.each do |pan|
-      @pangrams.push(pan.word_text) if Set.new(pan.word_text.chars).length == 7
-    end
-    @pangrams
+    @pangrams = Answer
+      .where(puzzle_id: id)
+      .where("length(word_text) >= 7")
+      .where(@valid_letters.map { |letter| "word_text LIKE '%#{letter}%'" }.join(" AND "))
+      .pluck(:word_text)
   end
 
   def set_perfect_pangrams
@@ -43,21 +55,6 @@ class Puzzle < ApplicationRecord
     @perfect_pangrams
   end
 
-  def set_excluded_words
-    set_valid_letters
-    @excluded_words ||= []
-    return unless @excluded_words.empty?
-    Word
-      .where("CHAR_LENGTH(text) >= 4")
-      .where("text ~ '^[#{@valid_letters.join("")}]+$'")
-      .where("text LIKE '%#{center_letter}%'")
-      .find_each do |checked_word|
-      unless words.include?(checked_word)
-        @excluded_words.push(checked_word.text)
-      end
-    end
-  end
-
   def set_is_latest
     @is_latest = Puzzle.last === self
   end
@@ -66,7 +63,6 @@ class Puzzle < ApplicationRecord
     set_valid_letters
     set_pangrams
     set_perfect_pangrams
-    set_excluded_words
     set_is_latest
   end
 
@@ -83,7 +79,7 @@ class Puzzle < ApplicationRecord
       answers: answers.map do |answer|
         answer.to_front_end
       end.sort_by { |answer| answer[:word] },
-      excludedWords: @excluded_words,
+      excludedWords: excluded_words,
       isLatest: @is_latest
     }
   end

--- a/app/services/nyt_scraper_service.rb
+++ b/app/services/nyt_scraper_service.rb
@@ -66,6 +66,8 @@ class NytScraperService
       end
       Answer.create!({puzzle: puzzle, word_text: answer})
     end
+    puzzle.create_excluded_words_cache
+    @logger.info "Created excluded words cache"
     @logger.info "Finished importing puzzle #{puzzle.id} for #{print_date}"
   end
 

--- a/app/services/sb_solver_scraper_service.rb
+++ b/app/services/sb_solver_scraper_service.rb
@@ -85,6 +85,8 @@ module SbSolverScraperService
           end
           Answer.create({puzzle: puzzle, word_text: item})
         end
+        puzzle.create_excluded_words_cache
+        write_log "Created excluded words cache"
         write_log "Finished importing puzzle #{id}"
       else
         write_log "Puzzle #{id} already exists. Moving to next puzzle."

--- a/db/migrate/20231119195913_add_excluded_words_to_puzzles.rb
+++ b/db/migrate/20231119195913_add_excluded_words_to_puzzles.rb
@@ -1,0 +1,16 @@
+# Super Spelling Bee - A vocabulary game with integrated hints
+# Copyright (C) 2023 Austin Miller
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# See the LICENSE file or https://www.gnu.org/licenses/ for more details.
+
+class AddExcludedWordsToPuzzles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :puzzles, :excluded_words, :string, array: true
+    add_index :puzzles, :excluded_words, using: :gin
+  end
+end

--- a/db/seeds/seed_excluded_words.rb
+++ b/db/seeds/seed_excluded_words.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "logger"
+
+class SeedExcludedWords
+  class ExcludedWordsSeederLogger < Logger
+    def initialize
+      super("log/excluded_words_seeder.log", "daily", 1024 * 1024 * 10)
+      @formatter = proc do |severity, datetime, _progname, msg|
+        timestamp = datetime.strftime("%Y-%m-%d %H:%M:%S")
+        "#{severity} #{timestamp} - #{msg}\n"
+      end
+    end
+  end
+
+  def initialize
+    @logger = ExcludedWordsSeederLogger.new
+  end
+
+  def seed_for_puzzle(puzzle)
+    @logger.info "Checking excluded words cache for puzzle #{puzzle.id}"
+    unless puzzle.excluded_words.nil?
+      return @logger.info "Cache already exists. Exiting"
+    end
+    @logger.info "Creating cache"
+    puzzle.create_excluded_words_cache
+  end
+
+  def test_seed
+    # Test seed function on five puzzles to start out with
+    Puzzle.first(5).each do |puzzle|
+      seed_for_puzzle(puzzle)
+    end
+  end
+
+  def seed_all
+    @logger.info "Seeding excluded words caches for all existing puzzles"
+    Puzzle.find_each(batch_size: 100) do |puzzle|
+      seed_for_puzzle(puzzle)
+    end
+  end
+
+  def delete_excluded_words
+    Puzzle.where.not(excluded_words: nil).update_all(excluded_words: nil)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,15 +1,3 @@
-/*
-  Super Spelling Bee - A vocabulary game with integrated hints
-  Copyright (C) 2023 Austin Miller
-
-  This program is free software: you can redistribute it and/or modify it under
-  the terms of the GNU General Public License as published by the Free Software
-  Foundation, either version 3 of the License, or (at your option) any later
-  version.
-
-  See the LICENSE file or https://www.gnu.org/licenses/ for more details.
-*/
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -416,7 +404,8 @@ CREATE TABLE public.puzzles (
     origin_type character varying,
     origin_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    excluded_words character varying[]
 );
 
 
@@ -1054,6 +1043,13 @@ CREATE INDEX index_hint_panels_on_status_tracking ON public.hint_panels USING bt
 
 
 --
+-- Name: index_puzzles_on_excluded_words; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_puzzles_on_excluded_words ON public.puzzles USING gin (excluded_words);
+
+
+--
 -- Name: index_puzzles_on_origin; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1345,6 +1341,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230913100015'),
 ('20231001001349'),
 ('20231002213304'),
-('20231011153938');
+('20231011153938'),
+('20231119195913');
 
 


### PR DESCRIPTION
## Description
The query for getting the base puzzle data was really slow on the back end, sometimes taking almost a full second. The browser tools in both production and dev indicated that this was due to waiting on the server to return a response.

The excluded words for each puzzle were being calculated on the fly, going through all 500k rows in the words table, grabbing all potentially valid words >4 letters and comparing them to the answer list to see if they were excluded or not. This PR changes the logic so that the excluded words are compiled when the puzzle is created and saved as an array in the puzzles table. While this is technically redundant, the increase in performance is immediately apparent and more than worth it.

Note that the existing puzzles need to be seeded in the production as they were in dev for the app to work properly.
