### PR TITLE
Finish OpenAI integration for definition hint generation

### DIFF
--- a/app/controllers/concerns/timestamp_converter.rb
+++ b/app/controllers/concerns/timestamp_converter.rb
@@ -10,7 +10,7 @@
 #
 # See the LICENSE file or https://www.gnu.org/licenses/ for more details.
 
-# Converts a Date.now() Unix timestamp (i.e., a millisecond timestamp created in JS)
+# Converts a Date.now() JS Unix timestamp (i.e., a millisecond timestamp created in JavaScript)
 # to a Ruby Time object
 module TimestampConverter
   extend ActiveSupport::Concern

--- a/app/controllers/front_end_api/v1/hint_panels_controller.rb
+++ b/app/controllers/front_end_api/v1/hint_panels_controller.rb
@@ -51,10 +51,12 @@ class FrontEndApi::V1::HintPanelsController < FrontEndApi::AuthRequiredControlle
     the_params = hint_panel_update_params
     if the_params[:initial_display_state_attributes] &&
        !@hint_panel.initial_display_state.update(the_params[:initial_display_state_attributes])
+
       raise RecordInvalidError.new(error_base, nil, @hint_panel.initial_display_state.errors)
     end
     if the_params[:current_display_state_attributes] &&
        !@hint_panel.current_display_state.update(the_params[:current_display_state_attributes])
+
       raise RecordInvalidError.new(error_base, nil, @hint_panel.current_display_state.errors)
     end
 
@@ -85,7 +87,8 @@ class FrontEndApi::V1::HintPanelsController < FrontEndApi::AuthRequiredControlle
         :panel_subtype_attributes,
       ),
     )
-      render json: @hint_panel.to_front_end, status: 200
+
+      render json: @hint_panel.to_front_end
     else
       raise RecordInvalidError.new(error_base, nil, @hint_panel.errors)
     end
@@ -106,6 +109,7 @@ class FrontEndApi::V1::HintPanelsController < FrontEndApi::AuthRequiredControlle
 
     if old_index > panels.size || new_index > panels.size || old_index.negative? ||
        new_index.negative? || old_index == new_index || panels.size < 2
+
       raise ApiError, "Invalid move"
     end
 

--- a/app/controllers/front_end_api/v1/user_prefs_controller.rb
+++ b/app/controllers/front_end_api/v1/user_prefs_controller.rb
@@ -42,6 +42,7 @@ class FrontEndApi::V1::UserPrefsController < FrontEndApi::AuthRequiredController
       current_hint_profile_type: params[:current_hint_profile_type],
       current_hint_profile_uuid: params[:current_hint_profile_uuid],
     )
+
       render json: @user_pref.current_hint_profile.to_front_end_complete
     end
   end

--- a/app/controllers/front_end_api/v1/user_puzzle_attempts_controller.rb
+++ b/app/controllers/front_end_api/v1/user_puzzle_attempts_controller.rb
@@ -57,7 +57,8 @@ class FrontEndApi::V1::UserPuzzleAttemptsController < FrontEndApi::AuthRequiredC
       .where(puzzle_id: puzzle.id).count
 
     if existing_attempts_count >= 10
-      raise ApiError, "#{error_base}: You've reached the maximum number of attempts for this puzzle."
+      raise ApiError,
+        "#{error_base}: You've reached the maximum number of attempts for this puzzle."
     end
 
     @user_puzzle_attempt = UserPuzzleAttempt.new(user_puzzle_attempt_params.except(:created_at))
@@ -112,7 +113,7 @@ class FrontEndApi::V1::UserPuzzleAttemptsController < FrontEndApi::AuthRequiredC
       item_status[:error] = error.to_front_end if error
       return_array.push(item_status)
     end
-    render json: return_array, status: 200
+    render json: return_array
   end
 
   private

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -18,7 +18,6 @@ class Answer < ApplicationRecord
   def to_front_end
     {
       word: word_text,
-      # Because Rails stores the frequency as a BigDecimal, it will be encoded as a string in JSON
       frequency: word.frequency,
       definitions: word.definitions,
       hint: word.hint,

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -21,6 +21,7 @@ class Answer < ApplicationRecord
       # Because Rails stores the frequency as a BigDecimal, it will be encoded as a string in JSON
       frequency: word.frequency,
       definitions: word.definitions,
+      hint: word.hint,
     }
   end
 end

--- a/app/models/puzzle.rb
+++ b/app/models/puzzle.rb
@@ -84,7 +84,7 @@ class Puzzle < ApplicationRecord
       validLetters: @valid_letters,
       pangrams: @pangrams,
       perfectPangrams: @perfect_pangrams,
-      answers: answers.map(&:to_front_end).sort_by { |answer| answer[:word] },
+      answers: words.map(&:to_front_end).sort_by { |word| word[:text] },
       excludedWords: excluded_words,
       isLatest: @is_latest,
     }

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -16,6 +16,10 @@ class Word < ApplicationRecord
   self.primary_key = :text
   has_many :answers, primary_key: :text, foreign_key: :word_text
   has_many :puzzles, through: :answers
+
+  def to_front_end
+    { text:, frequency:, definitions:, hint: }
+  end
 end
 
 # == Schema Information

--- a/bee-redux/src/features/definitionPanel/components/LetterTab.tsx
+++ b/bee-redux/src/features/definitionPanel/components/LetterTab.tsx
@@ -33,7 +33,7 @@ export function LetterTab({
           answer={answer}
           definitionPanelData={definitionPanelData}
           isKnown={false}
-          key={answer.word}
+          key={answer.text}
         />
       ))}
     </div>
@@ -51,7 +51,7 @@ export function LetterTab({
               answer={answer}
               definitionPanelData={definitionPanelData}
               isKnown={letterAnswers.known.includes(answer)}
-              key={answer.word}
+              key={answer.text}
             />
           ))}
         </div>
@@ -67,7 +67,7 @@ export function LetterTab({
               answer={answer}
               definitionPanelData={definitionPanelData}
               isKnown={true}
-              key={answer.word}
+              key={answer.text}
             />
           ))}
         </div>

--- a/bee-redux/src/features/definitionPanel/components/Word.tsx
+++ b/bee-redux/src/features/definitionPanel/components/Word.tsx
@@ -52,7 +52,7 @@ export function Word({
           {usageExplanation(answer.frequency).toLowerCase()})
         </div>
       ) : null}
-      <div>{answer.definitions[0]}</div>
+      <div>{answer.hint}</div>
     </div>
   );
 }

--- a/bee-redux/src/features/definitionPanel/components/Word.tsx
+++ b/bee-redux/src/features/definitionPanel/components/Word.tsx
@@ -30,9 +30,9 @@ export function Word({
   const { revealedLetters, showObscurity, revealLength } = definitionPanelData;
 
   const unknownWordDisplay = () => {
-    let returnStr = `${answer.word.slice(0, revealedLetters)}...`;
+    let returnStr = `${answer.text.slice(0, revealedLetters)}...`;
     if (revealLength) {
-      returnStr += ` ${answer.word.length}`;
+      returnStr += ` ${answer.text.length}`;
     }
     return returnStr;
   };
@@ -44,7 +44,7 @@ export function Word({
           ErrorText: !isKnown,
         })}
       >
-        {isKnown ? answer.word : unknownWordDisplay()}
+        {isKnown ? answer.text : unknownWordDisplay()}
       </div>
       {showObscurity ? (
         <div className="italic">

--- a/bee-redux/src/features/obscurityPanel/components/DefinitionPopover.tsx
+++ b/bee-redux/src/features/obscurityPanel/components/DefinitionPopover.tsx
@@ -26,7 +26,7 @@ export function DefinitionPopover({
         {displayString ?? answer.text}
       </Popover.Trigger>
       <Popover.ContentWithPortal>
-        <span>{answer.definitions[0]}</span>
+        <span>{answer.hint}</span>
       </Popover.ContentWithPortal>
     </Popover.Root>
   );

--- a/bee-redux/src/features/obscurityPanel/components/DefinitionPopover.tsx
+++ b/bee-redux/src/features/obscurityPanel/components/DefinitionPopover.tsx
@@ -23,7 +23,7 @@ export function DefinitionPopover({
   return (
     <Popover.Root>
       <Popover.Trigger className="DefinitionPopoverTrigger capitalize">
-        {displayString ?? answer.word}
+        {displayString ?? answer.text}
       </Popover.Trigger>
       <Popover.ContentWithPortal>
         <span>{answer.definitions[0]}</span>

--- a/bee-redux/src/features/obscurityPanel/components/ObscurityHintPanel.tsx
+++ b/bee-redux/src/features/obscurityPanel/components/ObscurityHintPanel.tsx
@@ -40,8 +40,8 @@ const displayUnknownWord = ({
   revealedLetters: number;
   revealLength: boolean;
 }) => {
-  let returnStr = `${answer.word.slice(0, revealedLetters)}...`;
-  if (revealLength) returnStr += ` ${answer.word.length}`;
+  let returnStr = `${answer.text.slice(0, revealedLetters)}...`;
+  if (revealLength) returnStr += ` ${answer.text.length}`;
   return returnStr;
 };
 
@@ -78,14 +78,14 @@ export function ObscurityHintPanel({
     }
 
     return answers.map((answer) => {
-      if (!hideKnown && knownWords.includes(answer.word)) {
+      if (!hideKnown && knownWords.includes(answer.text)) {
         return (
-          <tr key={answer.word}>
+          <tr key={answer.text}>
             <td className="capitalize">
               {clickToDefine ? (
                 <DefinitionPopover answer={answer} />
               ) : (
-                answer.word
+                answer.text
               )}
             </td>
             <td>{formatFrequency(answer.frequency)}</td>
@@ -96,7 +96,7 @@ export function ObscurityHintPanel({
         );
       }
       return (
-        <tr className="ErrorText" key={answer.word}>
+        <tr className="ErrorText" key={answer.text}>
           <td className="capitalize">
             {clickToDefine ? (
               <DefinitionPopover

--- a/bee-redux/src/features/progress/api/progressSlice.ts
+++ b/bee-redux/src/features/progress/api/progressSlice.ts
@@ -77,24 +77,24 @@ export const selectProgressShowTotalPoints = (state: RootState) =>
 export const selectKnownAnswers = createSelector(
   [selectAnswers, selectGuessWords],
   (answers, guessWords) =>
-    answers.filter((answer) => guessWords.includes(answer.word)),
+    answers.filter((answer) => guessWords.includes(answer.text)),
 );
 
 export const selectKnownAnswerWords = createSelector(
   [selectKnownAnswers],
-  (answers) => answers.map((answer) => answer.word),
+  (answers) => answers.map((answer) => answer.text),
 );
 
 export const selectRemainingAnswers = createSelector(
   [selectAnswers, selectKnownAnswerWords],
   (answers, knownWords) =>
-    answers.filter((answer) => !knownWords.includes(answer.word)),
+    answers.filter((answer) => !knownWords.includes(answer.text)),
 );
 
 export const selectRemainingAnswerWords = createSelector(
   [selectRemainingAnswers],
   (answers) => {
-    return answers.map((answer) => answer.word);
+    return answers.map((answer) => answer.text);
   },
 );
 
@@ -294,14 +294,14 @@ export const selectAnswersByLetter = createSelector(
     const desc: AnswersByLetter = {};
     const answersByLetterSortable: AnswersByLetterSortable = { asc, desc };
     for (const answer of answers) {
-      const firstLetter = answer.word[0];
+      const firstLetter = answer.text[0];
       if (asc[firstLetter] === undefined) {
         asc[firstLetter] = createLetterAnswers();
         desc[firstLetter] = createLetterAnswers();
       }
       asc[firstLetter].all.push(answer);
       desc[firstLetter].all.unshift(answer);
-      if (knownWords.includes(answer.word)) {
+      if (knownWords.includes(answer.text)) {
         asc[firstLetter].known.push(answer);
         desc[firstLetter].known.unshift(answer);
       } else {
@@ -310,8 +310,8 @@ export const selectAnswersByLetter = createSelector(
       }
     }
     for (const letter in asc) {
-      asc[letter].unknown.sort((a, b) => a.word.length - b.word.length);
-      desc[letter].unknown.sort((a, b) => b.word.length - a.word.length);
+      asc[letter].unknown.sort((a, b) => a.text.length - b.text.length);
+      desc[letter].unknown.sort((a, b) => b.text.length - a.text.length);
     }
     return answersByLetterSortable;
   },

--- a/bee-redux/src/features/puzzle/api/puzzleApiSlice.ts
+++ b/bee-redux/src/features/puzzle/api/puzzleApiSlice.ts
@@ -16,7 +16,6 @@ import { sortBy } from "lodash";
 import {
   generatePuzzleRanks,
   RawPuzzle,
-  TAnswer,
   TPuzzle,
 } from "@/features/puzzle/types/puzzleTypes";
 
@@ -27,15 +26,7 @@ export const puzzleApiSlice = apiSlice.injectEndpoints({
         url: `/puzzles/${identifier}`,
       }),
       transformResponse: (response: RawPuzzle, _meta, _arg) => {
-        const answerWords: string[] = [];
-        const processedAnswers: TAnswer[] = [];
-        response.answers.forEach((rawAnswer) => {
-          answerWords.push(rawAnswer.word);
-          processedAnswers.push({
-            ...rawAnswer,
-            frequency: Number(rawAnswer.frequency),
-          });
-        });
+        const answerWords = response.answers.map((answer) => answer.text);
         const answerLengths = (answerWords: string[]) => {
           const returnArray: number[] = [];
           for (const answer of answerWords) {
@@ -49,7 +40,6 @@ export const puzzleApiSlice = apiSlice.injectEndpoints({
 
         const processedResponse: TPuzzle = {
           ...response,
-          answers: processedAnswers,
           shuffledOuterLetters: [...response.outerLetters],
           answerWords,
           totalPoints,

--- a/bee-redux/src/features/puzzle/api/puzzleSlice.ts
+++ b/bee-redux/src/features/puzzle/api/puzzleSlice.ts
@@ -81,7 +81,7 @@ export const selectRanks = (state: RootState) => state.puzzle.data.ranks;
 
 export const selectAnswerWords = createSelector([selectAnswers], (answers) => {
   if (answers && answers.length > 0) {
-    return answers.map((answer) => answer.word);
+    return answers.map((answer) => answer.text);
   }
   return [];
 });

--- a/bee-redux/src/features/puzzle/types/puzzleTypes.ts
+++ b/bee-redux/src/features/puzzle/types/puzzleTypes.ts
@@ -120,22 +120,11 @@ export const getNextRank = (
   );
 };
 
-/** I'm saving frequency values in Rails as BigDecimals, just in case I need the precision in
- * the future. This might be unnecessary. Rails encodes BigDecimals in JSON as strings to save
- * precision, so RawAnswer's `frequency` prop is a string. Because I don't currently need precision
- * with the frequency data, I'm just converting that string to a normal number in JS for the
- * `TAnswer` type.
- */
-export type RawAnswer = {
-  word: string;
-  frequency: string;
-  definitions: string[];
-};
-
 export type TAnswer = {
-  word: string;
+  text: string;
   frequency: number;
   definitions: string[];
+  hint: string;
 };
 
 export type RawPuzzle = {
@@ -146,12 +135,12 @@ export type RawPuzzle = {
   validLetters: string[];
   pangrams: string[];
   perfectPangrams: string[];
-  answers: RawAnswer[];
+  answers: TAnswer[];
   excludedWords: string[];
   isLatest: boolean;
 };
 
-export type TPuzzle = Omit<RawPuzzle, "answers"> & {
+export type TPuzzle = RawPuzzle & {
   answers: TAnswer[];
   shuffledOuterLetters: string[];
   answerWords: string[];

--- a/bee-redux/src/features/wordLists/components/WordWithPopover.tsx
+++ b/bee-redux/src/features/wordLists/components/WordWithPopover.tsx
@@ -27,7 +27,7 @@ export function WordWithPopover({ item }: { item: string | TGuess }) {
   }
 
   const completeWord = useAppSelector(selectAnswers).find(
-    (answer) => answer.word === word,
+    (answer) => answer.text === word,
   );
   const pangrams = useAppSelector(selectPangrams);
   const isPangram = pangrams.includes(word);


### PR DESCRIPTION
## Description
This PR adds the UI components to the definition hints generated by the OpenAI API. It adds the hint field to the data sent to the front end, updates the TypeScript types, and changes the definition panel and obscurity panel to display the definition hints for words instead of the full definitions.

## Related Issues
Resolves #113

## Next Steps
The definition hints are unquestionably an improvement over the dictionary definitions for use in hint panels, but they are not perfect. Many hints still give away too much information, and some straight-up ignore the instructions, such as not to include any form of the root word in the hint. There will likely need to be iterative improvement on the hint generation logic before the hints are consistently generated correctly.

At a high level, this iterative improvement could include any of the following elements:
- UI functionality for marking words that have unacceptable hints and regenerating them (likely in batches)
- Using GPT 4 going forward and/or regenerating all existing hints using GPT 4 instead of GPT 3.5
- Refining the instructions for generating hints
- Fine-tuning an AI model for hint generation by giving it examples of good and bad hints